### PR TITLE
Compatibility with amqp client 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   directories:
   - "$HOME/.m2"
 
-script: "mvn cobertura:cobertura"
+script: "mvn cobertura:cobertura integration-test"
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 Mock for RabbitMQ Java [amqp-client](https://github.com/rabbitmq/rabbitmq-java-client).
 
-> Compatible with version **5.2.0** of [**com.rabbitmq:amqp-client**](https://github.com/rabbitmq/rabbitmq-java-client)
+> Compatible with versions **4.0.0** to **5.3.0** of [**com.rabbitmq:amqp-client**](https://github.com/rabbitmq/rabbitmq-java-client)
+
+> Compatible with versions **3.6.3** to **4.0.0** with the [`com.github.fridujo.rabbitmq.mock.compatibility` package](src/main/java/com/github/fridujo/rabbitmq/mock/compatibility/MockConnectionFactoryFactory.java).
 
 ### Motivation
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,19 +17,21 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <rabbitmq.client.version>5.2.0</rabbitmq.client.version>
+        <rabbitmq.client.version>5.3.0</rabbitmq.client.version>
 
-        <assertj.version>3.9.1</assertj.version>
-        <mockito.version>2.18.3</mockito.version>
+        <assertj.version>3.10.0</assertj.version>
+        <mockito.version>2.19.0</mockito.version>
         <micrometer.version>1.0.5</micrometer.version>
-        <spring.amqp.version>2.0.3.RELEASE</spring.amqp.version>
+        <spring.amqp.version>2.0.4.RELEASE</spring.amqp.version>
         <logback.version>1.2.3</logback.version>
 
-        <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
         <junit.jupiter.version>5.2.0</junit.jupiter.version>
         <junit.platform.version>1.2.0</junit.platform.version>
 
+        <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
+        <maven-invoker-plugin.version>3.1.0</maven-invoker-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+        <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
     </properties>
 
     <scm>
@@ -140,7 +142,7 @@
 
             <plugin>
                 <artifactId>maven-invoker-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${maven-invoker-plugin.version}</version>
                 <configuration>
                     <projectsDirectory>src/it</projectsDirectory>
                     <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
@@ -220,7 +222,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>${cobertura-maven-plugin.version}</version>
                     <configuration>
                         <formats>
                             <format>html</format>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
             <groupId>com.rabbitmq</groupId>
             <artifactId>amqp-client</artifactId>
             <version>${rabbitmq.client.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test dependencies -->
@@ -133,6 +134,67 @@
                         <goals>
                             <goal>jar-no-fork</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <projectsDirectory>src/it</projectsDirectory>
+                    <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                    <localRepositoryPath>target/local-repo</localRepositoryPath>
+                    <pomIncludes>
+                        <pomInclude>*/pom.xml</pomInclude>
+                    </pomIncludes>
+                    <filterProperties>
+                        <rabbitmq-mock.version>${project.version}</rabbitmq-mock.version>
+                    </filterProperties>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>install-dependencies</id>
+                        <goals>
+                            <goal>install</goal>
+                        </goals>
+                        <phase>integration-test</phase>
+                    </execution>
+                    <execution>
+                        <id>spring-boot-1.4.0</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>integration-test</phase>
+                        <configuration>
+                            <filterProperties>
+                                <spring-boot.version>1.4.0.RELEASE</spring-boot.version>
+                            </filterProperties>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>spring-boot-1.5.0</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>integration-test</phase>
+                        <configuration>
+                            <filterProperties>
+                                <spring-boot.version>1.5.0.RELEASE</spring-boot.version>
+                            </filterProperties>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>spring-boot-2.0.0</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>integration-test</phase>
+                        <configuration>
+                            <filterProperties>
+                                <spring-boot.version>2.0.0.RELEASE</spring-boot.version>
+                            </filterProperties>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/it/spring_boot/pom.xml
+++ b/src/it/spring_boot/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.fridujo</groupId>
+    <artifactId>rabbitmq-mock-spring-boot-integration</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <name>RabbitMQ-Mock Spring Boot Integration</name>
+    <description>Integration of RabbitMQ-Mock with Spring Boot</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
+        <spring-boot.version>@spring-boot.version@</spring-boot.version>
+        <rabbitmq-mock.version>@rabbitmq-mock.version@</rabbitmq-mock.version>
+        <!--<spring-boot.version>1.4.0.RELEASE</spring-boot.version>-->
+        <!--<rabbitmq-mock.version>1.0.4-SNAPSHOT</rabbitmq-mock.version>-->
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <!-- Import dependency management from Spring Boot -->
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.rabbitmq</groupId>
+                    <artifactId>http-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.fridujo</groupId>
+            <artifactId>rabbitmq-mock</artifactId>
+            <version>${rabbitmq-mock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/it/spring_boot/src/main/java/com/github/fridujo/rabbitmq/mock/integration/springboot/AmqpApplication.java
+++ b/src/it/spring_boot/src/main/java/com/github/fridujo/rabbitmq/mock/integration/springboot/AmqpApplication.java
@@ -1,0 +1,61 @@
+package com.github.fridujo.rabbitmq.mock.integration.springboot;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+import java.util.concurrent.TimeUnit;
+
+@SpringBootApplication
+public class AmqpApplication {
+
+    public final static String QUEUE_NAME = "spring-boot";
+
+    public static void main(String[] args) throws InterruptedException {
+        try (ConfigurableApplicationContext context = SpringApplication.run(AmqpApplication.class, args)) {
+            context.getBean(Sender.class).send();
+            Receiver receiver = context.getBean(Receiver.class);
+            while (receiver.getMessages().isEmpty()) {
+                TimeUnit.MILLISECONDS.sleep(100L);
+            }
+        }
+    }
+
+    @Bean
+    public Queue queue() {
+        return new Queue(QUEUE_NAME, false);
+    }
+
+    @Bean
+    public TopicExchange exchange() {
+        return new TopicExchange("spring-boot-exchange");
+    }
+
+    @Bean
+    public Binding binding(Queue queue, TopicExchange exchange) {
+        return BindingBuilder.bind(queue).to(exchange).with(QUEUE_NAME);
+    }
+
+    @Bean
+    public SimpleMessageListenerContainer container(ConnectionFactory connectionFactory,
+                                                    MessageListenerAdapter listenerAdapter) {
+        SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.setQueueNames(QUEUE_NAME);
+        container.setMessageListener(listenerAdapter);
+        return container;
+    }
+
+    @Bean
+    public MessageListenerAdapter listenerAdapter(Receiver receiver) {
+        return new MessageListenerAdapter(receiver, "receiveMessage");
+    }
+}

--- a/src/it/spring_boot/src/main/java/com/github/fridujo/rabbitmq/mock/integration/springboot/Receiver.java
+++ b/src/it/spring_boot/src/main/java/com/github/fridujo/rabbitmq/mock/integration/springboot/Receiver.java
@@ -1,0 +1,21 @@
+package com.github.fridujo.rabbitmq.mock.integration.springboot;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class Receiver {
+
+    private final List<String> messages = new ArrayList<>();
+
+    public void receiveMessage(String message) {
+        System.out.println("Received <" + message + ">");
+        this.messages.add(message);
+    }
+
+    public List<String> getMessages() {
+        return messages;
+    }
+}

--- a/src/it/spring_boot/src/main/java/com/github/fridujo/rabbitmq/mock/integration/springboot/Sender.java
+++ b/src/it/spring_boot/src/main/java/com/github/fridujo/rabbitmq/mock/integration/springboot/Sender.java
@@ -1,0 +1,19 @@
+package com.github.fridujo.rabbitmq.mock.integration.springboot;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Sender {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    public Sender(RabbitTemplate rabbitTemplate) {
+        this.rabbitTemplate = rabbitTemplate;
+    }
+
+    public void send() {
+        System.out.println("Sending message...");
+        rabbitTemplate.convertAndSend("", AmqpApplication.QUEUE_NAME, "Hello from RabbitMQ!");
+    }
+}

--- a/src/it/spring_boot/src/test/java/com/github/fridujo/rabbitmq/mock/integration/springboot/AmqpApplicationTest.java
+++ b/src/it/spring_boot/src/test/java/com/github/fridujo/rabbitmq/mock/integration/springboot/AmqpApplicationTest.java
@@ -1,0 +1,36 @@
+package com.github.fridujo.rabbitmq.mock.integration.springboot;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = AmqpApplicationTestConfiguration.class)
+public class AmqpApplicationTest {
+
+    @Autowired
+    private Sender sender;
+    @Autowired
+    private Receiver receiver;
+
+    @Test
+    public void message_is_received_when_sent_by_sender() throws InterruptedException {
+        sender.send();
+        List<String> receivedMessages = new ArrayList<>();
+        while (receivedMessages.isEmpty()) {
+            receivedMessages.addAll(receiver.getMessages());
+            TimeUnit.MILLISECONDS.sleep(100L);
+        }
+
+        assertThat(receivedMessages).containsExactly("Hello from RabbitMQ!");
+    }
+}
+

--- a/src/it/spring_boot/src/test/java/com/github/fridujo/rabbitmq/mock/integration/springboot/AmqpApplicationTestConfiguration.java
+++ b/src/it/spring_boot/src/test/java/com/github/fridujo/rabbitmq/mock/integration/springboot/AmqpApplicationTestConfiguration.java
@@ -1,0 +1,18 @@
+package com.github.fridujo.rabbitmq.mock.integration.springboot;
+
+import com.github.fridujo.rabbitmq.mock.compatibility.MockConnectionFactoryFactory;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import(AmqpApplication.class)
+class AmqpApplicationTestConfiguration {
+
+    @Bean
+    public ConnectionFactory connectionFactory() {
+        return new CachingConnectionFactory(MockConnectionFactoryFactory.build());
+    }
+}

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockChannel.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockChannel.java
@@ -469,7 +469,9 @@ public class MockChannel implements Channel {
 
     @Override
     public String basicConsume(String queue, boolean autoAck, String consumerTag, boolean noLocal, boolean exclusive, Map<String, Object> arguments, Consumer callback) {
-        return node.basicConsume(lastGeneratedIfEmpty(queue), autoAck, consumerTag, noLocal, exclusive, nullToEmpty(arguments), callback, this::nextDeliveryTag);
+        String serverConsumerTag = node.basicConsume(lastGeneratedIfEmpty(queue), autoAck, consumerTag, noLocal, exclusive, nullToEmpty(arguments), callback, this::nextDeliveryTag);
+        metricsCollectorWrapper.basicConsume(this, serverConsumerTag, autoAck);
+        return serverConsumerTag;
     }
 
     @Override
@@ -491,6 +493,7 @@ public class MockChannel implements Channel {
     public void basicCancel(String consumerTag) {
         // Called when BlockingQueueConsumer#basicCancel (after AbstractMessageListenerContainer#stop)
         node.basicCancel(consumerTag);
+        metricsCollectorWrapper.basicCancel(this, consumerTag);
     }
 
     @Override

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockConnectionFactory.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockConnectionFactory.java
@@ -1,8 +1,8 @@
 package com.github.fridujo.rabbitmq.mock;
 
+import com.github.fridujo.rabbitmq.mock.metrics.MetricsCollectorWrapper;
 import com.rabbitmq.client.AddressResolver;
 import com.rabbitmq.client.ConnectionFactory;
-import com.rabbitmq.client.NoOpMetricsCollector;
 
 import java.util.concurrent.ExecutorService;
 
@@ -12,7 +12,6 @@ public class MockConnectionFactory extends ConnectionFactory {
 
     public MockConnectionFactory() {
         setAutomaticRecoveryEnabled(false);
-        setMetricsCollector(new NoOpMetricsCollector());
     }
 
     @Override
@@ -21,7 +20,8 @@ public class MockConnectionFactory extends ConnectionFactory {
     }
 
     public MockConnection newConnection() {
-        MockConnection mockConnection = new MockConnection(mockNode, this::getMetricsCollector);
+        MetricsCollectorWrapper metricsCollectorWrapper = MetricsCollectorWrapper.Builder.build(this);
+        MockConnection mockConnection = new MockConnection(mockNode, metricsCollectorWrapper);
         return mockConnection;
     }
 }

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/compatibility/MockConnectionFactoryFactory.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/compatibility/MockConnectionFactoryFactory.java
@@ -1,0 +1,25 @@
+package com.github.fridujo.rabbitmq.mock.compatibility;
+
+import com.github.fridujo.rabbitmq.mock.MockConnectionFactory;
+import com.rabbitmq.client.ConnectionFactory;
+
+import static com.github.fridujo.rabbitmq.mock.tool.Classes.missingClass;
+
+public class MockConnectionFactoryFactory {
+
+    public static ConnectionFactory build() {
+        return build(MockConnectionFactoryFactory.class.getClassLoader());
+    }
+
+    public static ConnectionFactory build(ClassLoader classLoader) {
+        if (missingClass(classLoader, "com.rabbitmq.client.AddressResolver")) {
+            // AddressResolver appears in version 3.6.6 of amqp-client
+            // This execution branch is tested in spring-boot integration test with version 1.4.0.RELEASE
+            return new MockConnectionFactoryWithoutAddressResolver();
+        } else {
+            return new MockConnectionFactory();
+        }
+    }
+
+
+}

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/compatibility/MockConnectionFactoryFactory.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/compatibility/MockConnectionFactoryFactory.java
@@ -5,6 +5,10 @@ import com.rabbitmq.client.ConnectionFactory;
 
 import static com.github.fridujo.rabbitmq.mock.tool.Classes.missingClass;
 
+/**
+ * Factory building a mock implementation of {@link ConnectionFactory} according to the
+ * version of **amqp-client** present in the classpath.
+ */
 public class MockConnectionFactoryFactory {
 
     public static ConnectionFactory build() {
@@ -20,6 +24,4 @@ public class MockConnectionFactoryFactory {
             return new MockConnectionFactory();
         }
     }
-
-
 }

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/compatibility/MockConnectionFactoryWithoutAddressResolver.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/compatibility/MockConnectionFactoryWithoutAddressResolver.java
@@ -1,0 +1,31 @@
+package com.github.fridujo.rabbitmq.mock.compatibility;
+
+import com.github.fridujo.rabbitmq.mock.MockConnection;
+import com.github.fridujo.rabbitmq.mock.MockNode;
+import com.github.fridujo.rabbitmq.mock.metrics.MetricsCollectorWrapper;
+import com.rabbitmq.client.Address;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+public class MockConnectionFactoryWithoutAddressResolver extends ConnectionFactory {
+
+    private final MockNode mockNode = new MockNode();
+
+
+    public MockConnectionFactoryWithoutAddressResolver() {
+        setAutomaticRecoveryEnabled(false);
+    }
+
+    public Connection newConnection(ExecutorService executor, List<Address> addrs, String clientProvidedName) {
+        return newConnection();
+    }
+
+    public MockConnection newConnection() {
+        MetricsCollectorWrapper metricsCollectorWrapper = MetricsCollectorWrapper.Builder.build(this);
+        MockConnection mockConnection = new MockConnection(mockNode, metricsCollectorWrapper);
+        return mockConnection;
+    }
+}

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/metrics/ImplementedMetricsCollectorWrapper.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/metrics/ImplementedMetricsCollectorWrapper.java
@@ -1,0 +1,83 @@
+package com.github.fridujo.rabbitmq.mock.metrics;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.MetricsCollector;
+import com.rabbitmq.client.NoOpMetricsCollector;
+
+public class ImplementedMetricsCollectorWrapper implements MetricsCollectorWrapper {
+
+    private final ConnectionFactory connectionFactory;
+
+    ImplementedMetricsCollectorWrapper(ConnectionFactory connectionFactory) {
+        this.connectionFactory = connectionFactory;
+        if (connectionFactory.getMetricsCollector() == null) {
+            connectionFactory.setMetricsCollector(new NoOpMetricsCollector());
+        }
+    }
+
+    private MetricsCollector mc() {
+        return connectionFactory.getMetricsCollector();
+    }
+
+    @Override
+    public void newConnection(Connection connection) {
+        mc().newConnection(connection);
+    }
+
+    @Override
+    public void closeConnection(Connection connection) {
+        mc().closeConnection(connection);
+    }
+
+    @Override
+    public void newChannel(Channel channel) {
+        mc().newChannel(channel);
+    }
+
+    @Override
+    public void closeChannel(Channel channel) {
+        mc().closeChannel(channel);
+    }
+
+    @Override
+    public void basicPublish(Channel channel) {
+        mc().basicPublish(channel);
+    }
+
+    @Override
+    public void consumedMessage(Channel channel, long deliveryTag, boolean autoAck) {
+        mc().consumedMessage(channel, deliveryTag, autoAck);
+    }
+
+    @Override
+    public void consumedMessage(Channel channel, long deliveryTag, String consumerTag) {
+        mc().consumedMessage(channel, deliveryTag, consumerTag);
+    }
+
+    @Override
+    public void basicAck(Channel channel, long deliveryTag, boolean multiple) {
+        mc().basicAck(channel, deliveryTag, multiple);
+    }
+
+    @Override
+    public void basicNack(Channel channel, long deliveryTag) {
+        mc().basicNack(channel, deliveryTag);
+    }
+
+    @Override
+    public void basicReject(Channel channel, long deliveryTag) {
+        mc().basicReject(channel, deliveryTag);
+    }
+
+    @Override
+    public void basicConsume(Channel channel, String consumerTag, boolean autoAck) {
+        mc().basicConsume(channel, consumerTag, autoAck);
+    }
+
+    @Override
+    public void basicCancel(Channel channel, String consumerTag) {
+        mc().basicCancel(channel, consumerTag);
+    }
+}

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/metrics/MetricsCollectorWrapper.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/metrics/MetricsCollectorWrapper.java
@@ -1,0 +1,52 @@
+package com.github.fridujo.rabbitmq.mock.metrics;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+
+import static com.github.fridujo.rabbitmq.mock.tool.Classes.missingClass;
+
+public interface MetricsCollectorWrapper {
+
+    void newConnection(Connection connection);
+
+    void closeConnection(Connection connection);
+
+    void newChannel(Channel channel);
+
+    void closeChannel(Channel channel);
+
+    void basicPublish(Channel channel);
+
+    void consumedMessage(Channel channel, long deliveryTag, boolean autoAck);
+
+    void consumedMessage(Channel channel, long deliveryTag, String consumerTag);
+
+    void basicAck(Channel channel, long deliveryTag, boolean multiple);
+
+    void basicNack(Channel channel, long deliveryTag);
+
+    void basicReject(Channel channel, long deliveryTag);
+
+    void basicConsume(Channel channel, String consumerTag, boolean autoAck);
+
+    void basicCancel(Channel channel, String consumerTag);
+
+    class Builder {
+
+        public static MetricsCollectorWrapper build(ConnectionFactory connectionFactory) {
+            return build(MetricsCollectorWrapper.Builder.class.getClassLoader(), connectionFactory);
+        }
+
+        public static MetricsCollectorWrapper build(ClassLoader classLoader, ConnectionFactory connectionFactory) {
+            final MetricsCollectorWrapper metricsCollectorWrapper;
+            if (missingClass(classLoader, "com.rabbitmq.client.MetricsCollector")) {
+                metricsCollectorWrapper = new NoopMetricsCollectorWrapper();
+
+            } else {
+                metricsCollectorWrapper = new ImplementedMetricsCollectorWrapper(connectionFactory);
+            }
+            return metricsCollectorWrapper;
+        }
+    }
+}

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/metrics/NoopMetricsCollectorWrapper.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/metrics/NoopMetricsCollectorWrapper.java
@@ -1,0 +1,66 @@
+package com.github.fridujo.rabbitmq.mock.metrics;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+
+public class NoopMetricsCollectorWrapper implements MetricsCollectorWrapper {
+    @Override
+    public void newConnection(Connection connection) {
+        // no implementation
+    }
+
+    @Override
+    public void closeConnection(Connection connection) {
+        // no implementation
+    }
+
+    @Override
+    public void newChannel(Channel channel) {
+        // no implementation
+    }
+
+    @Override
+    public void closeChannel(Channel channel) {
+        // no implementation
+    }
+
+    @Override
+    public void basicPublish(Channel channel) {
+        // no implementation
+    }
+
+    @Override
+    public void consumedMessage(Channel channel, long deliveryTag, boolean autoAck) {
+        // no implementation
+    }
+
+    @Override
+    public void consumedMessage(Channel channel, long deliveryTag, String consumerTag) {
+        // no implementation
+    }
+
+    @Override
+    public void basicAck(Channel channel, long deliveryTag, boolean multiple) {
+        // no implementation
+    }
+
+    @Override
+    public void basicNack(Channel channel, long deliveryTag) {
+        // no implementation
+    }
+
+    @Override
+    public void basicReject(Channel channel, long deliveryTag) {
+        // no implementation
+    }
+
+    @Override
+    public void basicConsume(Channel channel, String consumerTag, boolean autoAck) {
+        // no implementation
+    }
+
+    @Override
+    public void basicCancel(Channel channel, String consumerTag) {
+        // no implementation
+    }
+}

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/tool/Classes.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/tool/Classes.java
@@ -1,0 +1,15 @@
+package com.github.fridujo.rabbitmq.mock.tool;
+
+public abstract class Classes {
+    private Classes() {
+    }
+
+    public static boolean missingClass(ClassLoader classLoader, String className) {
+        try {
+            classLoader.loadClass(className);
+            return false;
+        } catch (ClassNotFoundException e) {
+            return true;
+        }
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionFactoryTest.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionFactoryTest.java
@@ -1,5 +1,7 @@
 package com.github.fridujo.rabbitmq.mock;
 
+import com.github.fridujo.rabbitmq.mock.compatibility.MockConnectionFactoryWithoutAddressResolver;
+import com.rabbitmq.client.Address;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import org.junit.jupiter.api.Test;
@@ -8,6 +10,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
 import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,6 +39,15 @@ class MockConnectionFactoryTest {
         factory.setUri("amqp://userName:password@hostName:portNumber/virtualHost");
 
         Connection connection = factory.newConnection();
+
+        assertThat(connection).isInstanceOf(MockConnection.class);
+    }
+
+    @Test
+    void use_alternate_factory() throws IOException, TimeoutException {
+        ConnectionFactory factory = new MockConnectionFactoryWithoutAddressResolver();
+
+        Connection connection = factory.newConnection(null, (List<Address>) null, null);
 
         assertThat(connection).isInstanceOf(MockConnection.class);
     }

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/compatibility/MockConnectionFactoryFactoryTest.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/compatibility/MockConnectionFactoryFactoryTest.java
@@ -1,0 +1,32 @@
+package com.github.fridujo.rabbitmq.mock.compatibility;
+
+import com.github.fridujo.rabbitmq.mock.MockConnectionFactory;
+import com.rabbitmq.client.ConnectionFactory;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import static com.github.fridujo.rabbitmq.mock.tool.SafeArgumentMatchers.eq;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+class MockConnectionFactoryFactoryTest {
+
+    @Test
+    void current_version_resolve_AddressResolver() {
+        ConnectionFactory connectionFactory = MockConnectionFactoryFactory.build();
+
+        assertThat(connectionFactory).isExactlyInstanceOf(MockConnectionFactory.class);
+    }
+
+    @Test
+    void unresolved_AddressResolver_leads_to_alternate_connectionFactory() throws ClassNotFoundException {
+        ClassLoader classLoader = spy(new URLClassLoader(new URL[0], this.getClass().getClassLoader()));
+        doThrow(new ClassNotFoundException()).when(classLoader).loadClass(eq("com.rabbitmq.client.AddressResolver"));
+        ConnectionFactory connectionFactory = MockConnectionFactoryFactory.build(classLoader);
+
+        assertThat(connectionFactory).isExactlyInstanceOf(MockConnectionFactoryWithoutAddressResolver.class);
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/metrics/MetricsCollectorWrapperTest.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/metrics/MetricsCollectorWrapperTest.java
@@ -1,0 +1,55 @@
+package com.github.fridujo.rabbitmq.mock.metrics;
+
+import com.github.fridujo.rabbitmq.mock.MockConnectionFactory;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.github.fridujo.rabbitmq.mock.tool.SafeArgumentMatchers.eq;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+class MetricsCollectorWrapperTest {
+
+    @Test
+    void current_version_resolve_MetricsCollector() {
+        MetricsCollectorWrapper metricsCollectorWrapper = MetricsCollectorWrapper.Builder.build(new MockConnectionFactory());
+
+        assertThat(metricsCollectorWrapper).isExactlyInstanceOf(ImplementedMetricsCollectorWrapper.class);
+    }
+
+    @Test
+    void unresolved_MetricsCollector_leads_to_noop_implementation() throws ClassNotFoundException {
+        ClassLoader classLoader = spy(new URLClassLoader(new URL[0], this.getClass().getClassLoader()));
+        doThrow(new ClassNotFoundException()).when(classLoader).loadClass(eq("com.rabbitmq.client.MetricsCollector"));
+        MetricsCollectorWrapper metricsCollectorWrapper = MetricsCollectorWrapper.Builder.build(classLoader, new MockConnectionFactory());
+
+        assertThat(metricsCollectorWrapper).isExactlyInstanceOf(NoopMetricsCollectorWrapper.class);
+    }
+
+    @TestFactory
+    List<DynamicTest> noop_implementation_never_throws() {
+        MetricsCollectorWrapper metricsCollectorWrapper = new NoopMetricsCollectorWrapper();
+        return Arrays.asList(
+            dynamicTest("newConnection", () -> metricsCollectorWrapper.newConnection(null)),
+            dynamicTest("closeConnection", () -> metricsCollectorWrapper.closeConnection(null)),
+            dynamicTest("newChannel", () -> metricsCollectorWrapper.newChannel(null)),
+            dynamicTest("closeChannel", () -> metricsCollectorWrapper.closeChannel(null)),
+            dynamicTest("basicPublish", () -> metricsCollectorWrapper.basicPublish(null)),
+            dynamicTest("consumedMessage", () -> metricsCollectorWrapper.consumedMessage(null, 0L, true)),
+            dynamicTest("consumedMessage (consumerTag)", () -> metricsCollectorWrapper.consumedMessage(null, 0L, null)),
+            dynamicTest("basicAck", () -> metricsCollectorWrapper.basicAck(null, 0L, true)),
+            dynamicTest("basicNack", () -> metricsCollectorWrapper.basicNack(null, 0L)),
+            dynamicTest("basicReject", () -> metricsCollectorWrapper.basicReject(null, 0L)),
+            dynamicTest("basicConsume", () -> metricsCollectorWrapper.basicConsume(null, null, true)),
+            dynamicTest("basicCancel", () -> metricsCollectorWrapper.basicCancel(null, null))
+        );
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/tool/SafeArgumentMatchers.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/tool/SafeArgumentMatchers.java
@@ -1,0 +1,13 @@
+package com.github.fridujo.rabbitmq.mock.tool;
+
+import org.mockito.ArgumentMatchers;
+
+public abstract class SafeArgumentMatchers {
+    private SafeArgumentMatchers() {
+    }
+
+    public static String eq(String expected) {
+        ArgumentMatchers.eq(expected);
+        return "";
+    }
+}


### PR DESCRIPTION
Compatibility with old amqp client versions.

Introduce a new ConnectionFactory that is loadable with older versions