### PR TITLE
Add dead-letter-routing-key feature

### DIFF
--- a/src/main/java/com/github/fridujo/rabbitmq/mock/AmqArguments.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/AmqArguments.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 public class AmqArguments {
     private final String ALTERNATE_EXCHANGE_KEY = "alternate-exchange";
     private final String DEAD_LETTER_EXCHANGE_KEY = "x-dead-letter-exchange";
+    private final String DEAD_LETTER_ROUTING_KEY_KEY = "x-dead-letter-routing-key";
     private final String MESSAGE_TTL_KEY = "x-message-ttl";
     private final String QUEUE_MAX_LENGTH_KEY = "x-max-length";
     private final String QUEUE_MAX_LENGTH_BYTES_KEY = "x-max-length-bytes";
@@ -27,6 +28,10 @@ public class AmqArguments {
     public Optional<ReceiverPointer> getDeadLetterExchange() {
         return string(DEAD_LETTER_EXCHANGE_KEY)
             .map(aeName -> new ReceiverPointer(ReceiverPointer.Type.EXCHANGE, aeName));
+    }
+
+    public Optional<String> getDeadLetterRoutingKey() {
+        return string(DEAD_LETTER_ROUTING_KEY_KEY);
     }
 
     public Optional<Integer> queueLengthLimit() {

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockQueue.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockQueue.java
@@ -1,12 +1,5 @@
 package com.github.fridujo.rabbitmq.mock;
 
-import com.rabbitmq.client.AMQP;
-import com.rabbitmq.client.Consumer;
-import com.rabbitmq.client.Envelope;
-import com.rabbitmq.client.GetResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -21,6 +14,14 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Consumer;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.GetResponse;
 
 public class MockQueue implements Receiver {
     private static final Logger LOGGER = LoggerFactory.getLogger(MockQueue.class);
@@ -178,7 +179,7 @@ public class MockQueue implements Receiver {
             .flatMap(receiverRegistry::getReceiver)
             .ifPresent(deadLetterExchange -> deadLetterExchange.publish(
                 message.exchangeName,
-                message.routingKey,
+                arguments.getDeadLetterRoutingKey().orElse(message.routingKey),
                 message.props,
                 message.body)
             );


### PR DESCRIPTION
RabbitMQ allows assigning a new routing key to messages on dead lettering. (see https://www.rabbitmq.com/dlx.html) I did not find support for this in the library, so I added it.

Side note: really nice code! I actually had fun working in it.