### PR TITLE
after queue shut down stop delivering more messages

### DIFF
--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockQueue.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockQueue.java
@@ -66,6 +66,10 @@ public class MockQueue implements Receiver {
     }
 
     private boolean deliverToConsumerIfPossible() {
+        // break the delivery loop in case of a shutdown
+        if(!running.get()) {
+            return false;
+        }
         boolean delivered = false;
         if (consumersByTag.size() > 0) {
             Message message = messages.poll();

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/IntegrationTest.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/IntegrationTest.java
@@ -11,8 +11,10 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -89,5 +91,56 @@ class IntegrationTest {
                 }
             }
         }
+    }
+
+    @Test
+    void basic_consume_nack_case() throws IOException, TimeoutException, InterruptedException {
+        String exchangeName = "test-exchange";
+        String routingKey = "test.key";
+
+        AtomicInteger atomicInteger = new AtomicInteger();
+        final Semaphore semaphore = new Semaphore(0);
+
+        try (Connection conn = new MockConnectionFactory().newConnection()) {
+            assertThat(conn).isInstanceOf(MockConnection.class);
+
+            try (Channel channel = conn.createChannel()) {
+                assertThat(channel).isInstanceOf(MockChannel.class);
+
+                channel.exchangeDeclare(exchangeName, "direct", true);
+                String queueName = channel.queueDeclare().getQueue();
+                channel.queueBind(queueName, exchangeName, routingKey);
+
+                channel.basicConsume(queueName, false, "myConsumerTag",
+                    new DefaultConsumer(channel) {
+                        @Override
+                        public void handleDelivery(String consumerTag,
+                                                   Envelope envelope,
+                                                   AMQP.BasicProperties properties,
+                                                   byte[] body) throws IOException {
+                            semaphore.release();
+                            long deliveryTag = envelope.getDeliveryTag();
+                            atomicInteger.incrementAndGet();
+                            channel.basicNack(deliveryTag, false, true);
+                        }
+                    });
+
+                byte[] messageBodyBytes = "Hello, world!".getBytes();
+                channel.basicPublish(exchangeName, routingKey, null, messageBodyBytes);
+                semaphore.acquire();
+
+            }
+
+        }
+
+        // WHEN after closing the connection and resetting the counter
+        atomicInteger.set(0);
+
+        TimeUnit.MILLISECONDS.sleep(100L);
+        assertThat(atomicInteger.get())
+            .describedAs("even after a few milliseconds, the consumer should not have been invoked on the message")
+            .isZero();
+
+
     }
 }


### PR DESCRIPTION
Given a queue contains a message that is being nacked by the consumer, we need to break the consumption loop upon connection shutdown, otherwise the consumer will continue to process messages.

This behavior resembles the behavior of a real [rabbitmq connection](https://github.com/rabbitmq/rabbitmq-java-client/blob/cebcc8f65a7c859f4a134e80480d0f5a4ef46c87/src/main/java/com/rabbitmq/client/impl/ConsumerDispatcher.java#L139-L152) that cannot receive more messages after a shutdown.
