### PR TITLE
Fix race condition on the message queue

### DIFF
--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockQueue.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockQueue.java
@@ -9,11 +9,11 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
-import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -50,7 +50,7 @@ public class MockQueue implements Receiver {
         this.receiverRegistry = receiverRegistry;
         this.mockChannel = mockChannel;
 
-        messages = new PriorityQueue<>(new MessageComparator(arguments));
+        messages = new PriorityBlockingQueue<>(new MessageComparator(arguments));
         start();
     }
 


### PR DESCRIPTION
The messages queue is accessed and mutated concurrently by both consumer and producer threads.

Quoting the PriorityQueue javadoc documentation: 
> Multiple threads should not access a PriorityQueue instance concurrently if any of the threads modifies the queue. Instead, use the thread-safe PriorityBlockingQueue class. 

I'm actually facing this situation in my project where once in a while a message gets lost causing the tests to fail.

Thank you for this great open source project!