### PR TITLE
Fix dead-lettering for queue without consumer

### DIFF
--- a/src/main/java/com/github/fridujo/rabbitmq/mock/AmqArguments.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/AmqArguments.java
@@ -5,15 +5,14 @@ import java.util.Map;
 import java.util.Optional;
 
 public class AmqArguments {
+    public static final String DEAD_LETTER_EXCHANGE_KEY = "x-dead-letter-exchange";
+    public static final String DEAD_LETTER_ROUTING_KEY_KEY = "x-dead-letter-routing-key";
+    public static final String MESSAGE_TTL_KEY = "x-message-ttl";
+    public static final String QUEUE_MAX_LENGTH_KEY = "x-max-length";
+    public static final String QUEUE_MAX_LENGTH_BYTES_KEY = "x-max-length-bytes";
+    public static final String OVERFLOW_KEY = "x-overflow";
+    public static final String MAX_PRIORITY_KEY = "x-max-priority";
     private final String ALTERNATE_EXCHANGE_KEY = "alternate-exchange";
-    private final String DEAD_LETTER_EXCHANGE_KEY = "x-dead-letter-exchange";
-    private final String DEAD_LETTER_ROUTING_KEY_KEY = "x-dead-letter-routing-key";
-    private final String MESSAGE_TTL_KEY = "x-message-ttl";
-    private final String QUEUE_MAX_LENGTH_KEY = "x-max-length";
-    private final String QUEUE_MAX_LENGTH_BYTES_KEY = "x-max-length-bytes";
-    private final String OVERFLOW_KEY = "x-overflow";
-    private final String MAX_PRIORITY_KEY = "x-max-priority";
-
     private final Map<String, Object> arguments;
 
     public AmqArguments(Map<String, Object> arguments) {
@@ -88,5 +87,9 @@ public class AmqArguments {
             return Arrays.stream(values()).filter(v -> value.equals(v.stringValue)).findFirst();
         }
 
+        @Override
+        public String toString() {
+            return stringValue;
+        }
     }
 }

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockQueue.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockQueue.java
@@ -27,6 +27,8 @@ import com.rabbitmq.client.GetResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.fridujo.rabbitmq.mock.tool.NamedThreadFactory;
+
 public class MockQueue implements Receiver {
     private static final Logger LOGGER = LoggerFactory.getLogger(MockQueue.class);
     private static final long SLEEPING_TIME_BETWEEN_SUBMISSIONS_TO_CONSUMERS = 30L;
@@ -37,11 +39,11 @@ public class MockQueue implements Receiver {
     private final ReceiverRegistry receiverRegistry;
     private final MockChannel mockChannel;
     private final Queue<Message> messages;
+    private final ExecutorService executorService;
     private final Map<String, ConsumerAndTag> consumersByTag = new LinkedHashMap<>();
     private final AtomicInteger consumerRollingSequence = new AtomicInteger();
     private final AtomicInteger messageSequence = new AtomicInteger();
     private final Map<Long, Message> unackedMessagesByDeliveryTag = new LinkedHashMap<>();
-    private final ExecutorService executorService = Executors.newFixedThreadPool(1);
     private final AtomicBoolean running = new AtomicBoolean(true);
 
     public MockQueue(String name, AmqArguments arguments, ReceiverRegistry receiverRegistry, MockChannel mockChannel) {
@@ -52,6 +54,7 @@ public class MockQueue implements Receiver {
         this.mockChannel = mockChannel;
 
         messages = new PriorityBlockingQueue<>(11, new MessageComparator(arguments));
+        executorService = Executors.newFixedThreadPool(1, new NamedThreadFactory(i -> name + "_queue_consuming"));
         start();
     }
 

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/configuration/QueueDeclarator.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/configuration/QueueDeclarator.java
@@ -1,0 +1,73 @@
+package com.github.fridujo.rabbitmq.mock.configuration;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+
+import com.github.fridujo.rabbitmq.mock.AmqArguments;
+import com.github.fridujo.rabbitmq.mock.MockChannel;
+
+public class QueueDeclarator {
+
+    private final String queueName;
+    private final Map<String, Object> queueArgs = new LinkedHashMap<>();
+
+    private QueueDeclarator(String queueName) {
+        this.queueName = queueName;
+    }
+
+    public static QueueDeclarator queue(String queueName) {
+        return new QueueDeclarator(queueName);
+    }
+
+    public static QueueDeclarator dynamicQueue() {
+        return queue("");
+    }
+
+    public QueueDeclarator withMessageTtl(long messageTtl) {
+        queueArgs.put(AmqArguments.MESSAGE_TTL_KEY, messageTtl);
+        return this;
+    }
+
+
+    public QueueDeclarator withDeadLetterExchange(String deadLetterExchange) {
+        queueArgs.put(AmqArguments.DEAD_LETTER_EXCHANGE_KEY, deadLetterExchange);
+        return this;
+    }
+
+    public QueueDeclarator withDeadLetterRoutingKey(String deadLetterRoutingKey) {
+        queueArgs.put(AmqArguments.DEAD_LETTER_ROUTING_KEY_KEY, deadLetterRoutingKey);
+        return this;
+    }
+
+    public QueueDeclarator withMaxLength(int maxLength) {
+        queueArgs.put(AmqArguments.QUEUE_MAX_LENGTH_KEY, maxLength);
+        return this;
+    }
+
+    public QueueDeclarator withMaxLengthBytes(int maxLengthBytes) {
+        queueArgs.put(AmqArguments.QUEUE_MAX_LENGTH_BYTES_KEY, maxLengthBytes);
+        return this;
+    }
+
+    public QueueDeclarator withOverflow(AmqArguments.Overflow overflow) {
+        queueArgs.put(AmqArguments.OVERFLOW_KEY, overflow.toString());
+        return this;
+    }
+
+    public QueueDeclarator withMaxPriority(int maxPriority) {
+        queueArgs.put(AmqArguments.MAX_PRIORITY_KEY, maxPriority);
+        return this;
+    }
+
+    public AMQP.Queue.DeclareOk declare(Channel channel) throws IOException {
+        return channel.queueDeclare(queueName, true, false, false, queueArgs);
+    }
+
+    public AMQP.Queue.DeclareOk declare(MockChannel channel) {
+        return channel.queueDeclare(queueName, true, false, false, queueArgs);
+    }
+}

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/tool/NamedThreadFactory.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/tool/NamedThreadFactory.java
@@ -1,0 +1,23 @@
+package com.github.fridujo.rabbitmq.mock.tool;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+public class NamedThreadFactory implements ThreadFactory {
+
+    private final ThreadGroup group;
+    private final AtomicInteger threadNumber = new AtomicInteger(1);
+    private final Function<Integer, String> nameCreator;
+
+    public NamedThreadFactory(Function<Integer, String> nameCreator) {
+        this.nameCreator = nameCreator;
+        SecurityManager s = System.getSecurityManager();
+        group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        return new Thread(group, r, nameCreator.apply(threadNumber.getAndIncrement()), 0);
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/ComplexUseCasesTests.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/ComplexUseCasesTests.java
@@ -1,0 +1,138 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import static com.github.fridujo.rabbitmq.mock.configuration.QueueDeclarator.queue;
+import static com.github.fridujo.rabbitmq.mock.tool.Exceptions.runAndEatExceptions;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.BuiltinExchangeType;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.DefaultConsumer;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.GetResponse;
+import org.junit.jupiter.api.Test;
+
+class ComplexUseCasesTests {
+
+    @Test
+    void expired_message_should_be_consumable_after_being_dead_lettered() throws IOException, TimeoutException, InterruptedException {
+        try (Connection conn = new MockConnectionFactory().newConnection()) {
+            try (Channel channel = conn.createChannel()) {
+                channel.exchangeDeclare("rejected-ex", BuiltinExchangeType.FANOUT);
+                channel.queueDeclare("rejected", true, false, false, null);
+                channel.queueBindNoWait("rejected", "rejected-ex", "unused", null);
+                queue("fruits").withMessageTtl(10L).withDeadLetterExchange("rejected-ex").declare(channel);
+
+                List<String> messages = new ArrayList<>();
+                channel.basicConsume("rejected", new DefaultConsumer(channel) {
+                    @Override
+                    public void handleDelivery(String consumerTag,
+                                               Envelope envelope,
+                                               AMQP.BasicProperties properties,
+                                               byte[] body) {
+                        messages.add(new String(body));
+                    }
+                });
+
+                channel.basicPublish("", "fruits", null, "banana".getBytes());
+                TimeUnit.MILLISECONDS.sleep(100L);
+                assertThat(messages).hasSize(1);
+            }
+        }
+    }
+
+    @Test
+    void multiple_expired_messages_are_not_delivered_to_consumer() throws IOException, TimeoutException, InterruptedException {
+        try (Connection conn = new MockConnectionFactory().newConnection()) {
+            try (Channel channel = conn.createChannel()) {
+                queue("fruits").withMessageTtl(-1L).declare(channel);
+
+                List<String> messages = new ArrayList<>();
+                channel.basicConsume("fruits", new DefaultConsumer(channel) {
+                    @Override
+                    public void handleDelivery(String consumerTag,
+                                               Envelope envelope,
+                                               AMQP.BasicProperties properties,
+                                               byte[] body) {
+                        messages.add(new String(body));
+                    }
+                });
+
+                channel.basicPublish("", "fruits", null, "banana".getBytes());
+                channel.basicPublish("", "fruits", null, "orange".getBytes());
+                TimeUnit.MILLISECONDS.sleep(100L);
+                assertThat(messages).hasSize(0);
+            }
+        }
+    }
+
+    @Test
+    void expired_message_should_be_consumable_after_being_dead_lettered_with_ttl_per_message() throws IOException, TimeoutException, InterruptedException {
+        try (Connection conn = new MockConnectionFactory().newConnection()) {
+            try (Channel channel = conn.createChannel()) {
+                channel.exchangeDeclare("rejected-ex", BuiltinExchangeType.FANOUT);
+                queue("rejected").declare(channel);
+                channel.queueBindNoWait("rejected", "rejected-ex", "unused", null);
+                queue("fruits").withDeadLetterExchange("rejected-ex").declare(channel);
+
+                List<String> messages = new ArrayList<>();
+                channel.basicConsume("rejected", new DefaultConsumer(channel) {
+                    @Override
+                    public void handleDelivery(String consumerTag,
+                                               Envelope envelope,
+                                               AMQP.BasicProperties properties,
+                                               byte[] body) {
+                        messages.add(new String(body));
+                    }
+                });
+
+                AMQP.BasicProperties properties = new AMQP.BasicProperties.Builder()
+                    .expiration("50")
+                    .build();
+                channel.basicPublish("", "fruits", properties, "banana".getBytes());
+                TimeUnit.MILLISECONDS.sleep(150L);
+                assertThat(messages).hasSize(1);
+            }
+        }
+    }
+
+    @Test
+    void basicGet_expired_message_while_consumer_is_active() throws IOException, TimeoutException, InterruptedException {
+        try (Connection conn = new MockConnectionFactory().newConnection()) {
+            Semaphore consuming = new Semaphore(0);
+            try (Channel channel = conn.createChannel()) {
+                queue("fruits").declare(channel);
+
+                channel.basicConsume("fruits", new DefaultConsumer(channel) {
+                    @Override
+                    public void handleDelivery(String consumerTag,
+                                               Envelope envelope,
+                                               AMQP.BasicProperties properties,
+                                               byte[] body) {
+                        runAndEatExceptions(consuming::acquire); // will consume banana
+                    }
+                });
+
+                AMQP.BasicProperties properties = new AMQP.BasicProperties.Builder()
+                    .expiration("50")
+                    .build();
+                channel.basicPublish("", "fruits", null, "banana".getBytes());
+                channel.basicPublish("", "fruits", properties, "kiwi".getBytes());
+
+                TimeUnit.MILLISECONDS.sleep(80L);
+
+                GetResponse kiwiMessage = channel.basicGet("fruits", true);
+                assertThat(kiwiMessage).isNull(); // dead-lettered but not by the queue event-loop
+                consuming.release();
+            }
+        }
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/ExtensionTest.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/ExtensionTest.java
@@ -1,5 +1,7 @@
 package com.github.fridujo.rabbitmq.mock;
 
+import static com.github.fridujo.rabbitmq.mock.configuration.QueueDeclarator.dynamicQueue;
+import static com.github.fridujo.rabbitmq.mock.configuration.QueueDeclarator.queue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
@@ -15,11 +17,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.IntStream;
 
-import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestFactory;
-
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.BuiltinExchangeType;
 import com.rabbitmq.client.Channel;
@@ -28,6 +25,10 @@ import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Envelope;
 import com.rabbitmq.client.GetResponse;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 
 class ExtensionTest {
 
@@ -88,10 +89,10 @@ class ExtensionTest {
             try (Channel channel = conn.createChannel()) {
                 channel.queueDeclare("rejected", true, false, false, null);
                 channel.queueBindNoWait("rejected", "", "rejected", null);
-                Map<String,Object> queueArgs = new HashMap<>();
-                queueArgs.put("x-dead-letter-routing-key", "rejected");
-                queueArgs.put("x-dead-letter-exchange", "");
-                channel.queueDeclare("fruits", true, false, false, queueArgs);
+                queue("fruits")
+                    .withDeadLetterExchange("")
+                    .withDeadLetterRoutingKey("rejected")
+                    .declare(channel);
 
                 channel.basicPublish("", "fruits", null, "banana".getBytes());
                 GetResponse getResponse = channel.basicGet("fruits", false);
@@ -114,9 +115,7 @@ class ExtensionTest {
         void message_ttl_for_queue_keeps_messages_while_expiration_not_reached() throws IOException, TimeoutException {
             try (Connection conn = new MockConnectionFactory().newConnection()) {
                 try (Channel channel = conn.createChannel()) {
-                    Map<String, Object> args = new HashMap<>();
-                    args.put("x-message-ttl", 700);
-                    channel.queueDeclare("fruits", true, false, false, args);
+                    queue("fruits").withMessageTtl(700).declare(channel);
                     channel.basicPublish("", "fruits", null, "banana".getBytes());
                     GetResponse getResponse = channel.basicGet("fruits", true);
                     assertThat(getResponse).isNotNull();
@@ -131,11 +130,11 @@ class ExtensionTest {
                     channel.exchangeDeclare("rejected-ex", BuiltinExchangeType.FANOUT);
                     channel.queueDeclare("rejected", true, false, false, null);
                     channel.queueBindNoWait("rejected", "rejected-ex", "unused", null);
+                    queue("fruits")
+                        .withMessageTtl(200)
+                        .withDeadLetterExchange("rejected-ex")
+                        .declare(channel);
 
-                    Map<String, Object> args = new HashMap<>();
-                    args.put("x-message-ttl", 200);
-                    args.put("x-dead-letter-exchange", "rejected-ex");
-                    channel.queueDeclare("fruits", true, false, false, args);
                     channel.basicPublish("", "fruits", null, "banana".getBytes());
                     TimeUnit.MILLISECONDS.sleep(400L);
                     GetResponse getResponse = channel.basicGet("fruits", true);
@@ -151,10 +150,8 @@ class ExtensionTest {
         void message_ttl_for_queue_reject_messages_after_expiration_is_reached_using_consumer() throws IOException, TimeoutException, InterruptedException {
             try (Connection conn = new MockConnectionFactory().newConnection()) {
                 try (Channel channel = conn.createChannel()) {
+                    queue("fruits").withMessageTtl(100).declare(channel);
 
-                    Map<String, Object> args = new HashMap<>();
-                    args.put("x-message-ttl", 100);
-                    channel.queueDeclare("fruits", true, false, false, args);
                     channel.basicPublish("", "fruits", null, "banana".getBytes());
                     TimeUnit.MILLISECONDS.sleep(300L);
 
@@ -382,9 +379,7 @@ class ExtensionTest {
         void oldest_message_is_dropped_when_length_limit_is_reached() {
             try (MockConnection conn = new MockConnectionFactory().newConnection()) {
                 try (MockChannel channel = conn.createChannel()) {
-                    Map<String, Object> arguments = new HashMap<>();
-                    arguments.put("x-max-length", 2);
-                    String queueName = channel.queueDeclare("", true, true, false, arguments).getQueue();
+                    String queueName = dynamicQueue().withMaxLength(2).declare(channel).getQueue();
 
                     IntStream.range(0, 6).forEach(i ->
                         channel.basicPublish("", queueName, null, Integer.valueOf(i).toString().getBytes())
@@ -404,9 +399,7 @@ class ExtensionTest {
         void oldest_message_is_dropped_when_length_bytes_limit_is_reached() {
             try (MockConnection conn = new MockConnectionFactory().newConnection()) {
                 try (MockChannel channel = conn.createChannel()) {
-                    Map<String, Object> arguments = new HashMap<>();
-                    arguments.put("x-max-length-bytes", 10);
-                    String queueName = channel.queueDeclare("", true, true, false, arguments).getQueue();
+                    String queueName = dynamicQueue().withMaxLengthBytes(10).declare(channel).getQueue();
 
                     IntStream.range(0, 6).forEach(i ->
                         channel.basicPublish("", queueName, null, ("hello " + i).getBytes())
@@ -426,10 +419,11 @@ class ExtensionTest {
         void new_message_is_dropped_when_length_limit_is_reached_and_overflow_is_set_to_reject_publish() {
             try (MockConnection conn = new MockConnectionFactory().newConnection()) {
                 try (MockChannel channel = conn.createChannel()) {
-                    Map<String, Object> arguments = new HashMap<>();
-                    arguments.put("x-max-length", 2);
-                    arguments.put("x-overflow", "reject-publish");
-                    String queueName = channel.queueDeclare("", true, true, false, arguments).getQueue();
+                    String queueName = dynamicQueue()
+                        .withMaxLength(2)
+                        .withOverflow(AmqArguments.Overflow.REJECT_PUBLISH)
+                        .declare(channel)
+                        .getQueue();
 
                     IntStream.range(0, 6).forEach(i ->
                         channel.basicPublish("", queueName, null, Integer.valueOf(i).toString().getBytes())
@@ -473,9 +467,7 @@ class ExtensionTest {
         void nominal_use() {
             try (MockConnection conn = new MockConnectionFactory().newConnection()) {
                 try (MockChannel channel = conn.createChannel()) {
-                    Map<String, Object> arguments = new HashMap<>();
-                    arguments.put("x-max-priority", 10);
-                    String queueName = channel.queueDeclare("", true, true, false, arguments).getQueue();
+                    String queueName = dynamicQueue().withMaxPriority(10).declare(channel).getQueue();
 
                     channel.basicPublish("", queueName, new AMQP.BasicProperties.Builder().priority(2).build(), "first".getBytes());
                     channel.basicPublish("", queueName, new AMQP.BasicProperties.Builder().priority(6).build(), "second".getBytes());
@@ -493,9 +485,7 @@ class ExtensionTest {
         void no_priority_is_considered_zero() {
             try (MockConnection conn = new MockConnectionFactory().newConnection()) {
                 try (MockChannel channel = conn.createChannel()) {
-                    Map<String, Object> arguments = new HashMap<>();
-                    arguments.put("x-max-priority", 10);
-                    String queueName = channel.queueDeclare("", true, true, false, arguments).getQueue();
+                    String queueName = dynamicQueue().withMaxPriority(10).declare(channel).getQueue();
 
                     channel.basicPublish("", queueName, null, "first".getBytes());
                     channel.basicPublish("", queueName, new AMQP.BasicProperties.Builder().priority(2).build(), "second".getBytes());
@@ -519,9 +509,7 @@ class ExtensionTest {
         private void withMaxPriority(int priority) {
             try (MockConnection conn = new MockConnectionFactory().newConnection()) {
                 try (MockChannel channel = conn.createChannel()) {
-                    Map<String, Object> arguments = new HashMap<>();
-                    arguments.put("x-max-priority", priority);
-                    String queueName = channel.queueDeclare("", true, true, false, arguments).getQueue();
+                    String queueName = dynamicQueue().withMaxPriority(priority).declare(channel).getQueue();
 
                     channel.basicPublish("", queueName, new AMQP.BasicProperties.Builder().priority(16).build(), "first".getBytes());
                     channel.basicPublish("", queueName, new AMQP.BasicProperties.Builder().priority(18).build(), "second".getBytes());

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -3,11 +3,12 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36}.%L - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36}.%L - %msg%n</pattern>
         </encoder>
     </appender>
 
     <logger name="org.springframework" level="WARN"/>
+    <logger name="com.github.fridujo.rabbitmq.mock" level="WARN"/>
 
     <root level="DEBUG">
         <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
Fix for #28 , and for an issue with TTL per message feature (expiry time computation was wrong).