### PR TITLE
Ability to register other types of exchange

### DIFF
--- a/src/main/java/com/github/fridujo/rabbitmq/mock/ConfigurableConnectionFactory.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/ConfigurableConnectionFactory.java
@@ -2,7 +2,15 @@ package com.github.fridujo.rabbitmq.mock;
 
 import com.rabbitmq.client.ConnectionFactory;
 
+import com.github.fridujo.rabbitmq.mock.exchange.MockExchangeCreator;
+
 public abstract class ConfigurableConnectionFactory<T extends ConfigurableConnectionFactory> extends ConnectionFactory {
 
     protected final MockNode mockNode = new MockNode();
+    
+    @SuppressWarnings("unchecked")
+    public T withAdditionalExchange(MockExchangeCreator mockExchangeCreator) {
+        mockNode.getConfiguration().registerAdditionalExchangeCreator(mockExchangeCreator);
+        return (T) this;
+    }
 }

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/ConfigurableConnectionFactory.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/ConfigurableConnectionFactory.java
@@ -1,0 +1,8 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import com.rabbitmq.client.ConnectionFactory;
+
+public abstract class ConfigurableConnectionFactory<T extends ConfigurableConnectionFactory> extends ConnectionFactory {
+
+    protected final MockNode mockNode = new MockNode();
+}

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockConnectionFactory.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockConnectionFactory.java
@@ -6,9 +6,7 @@ import com.rabbitmq.client.ConnectionFactory;
 
 import java.util.concurrent.ExecutorService;
 
-public class MockConnectionFactory extends ConnectionFactory {
-
-    private final MockNode mockNode = new MockNode();
+public class MockConnectionFactory extends ConfigurableConnectionFactory<MockConnectionFactory> {
 
     public MockConnectionFactory() {
         setAutomaticRecoveryEnabled(false);

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockNode.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockNode.java
@@ -18,6 +18,7 @@ import com.github.fridujo.rabbitmq.mock.exchange.MockExchangeFactory;
 public class MockNode implements ReceiverRegistry, TransactionalOperations {
 
     private final Configuration configuration = new Configuration();
+    private final MockExchangeFactory mockExchangeFactory = new MockExchangeFactory(configuration);
     private final MockDefaultExchange defaultExchange = new MockDefaultExchange(this);
     private final Map<String, MockExchange> exchanges = new ConcurrentHashMap<>();
     private final Map<String, MockQueue> queues = new ConcurrentHashMap<>();
@@ -54,7 +55,7 @@ public class MockNode implements ReceiverRegistry, TransactionalOperations {
     }
 
     public AMQP.Exchange.DeclareOk exchangeDeclare(String exchangeName, String type, boolean durable, boolean autoDelete, boolean internal, Map<String, Object> arguments) {
-        exchanges.put(exchangeName, MockExchangeFactory.build(exchangeName, type, new AmqArguments(arguments), this));
+        exchanges.put(exchangeName, mockExchangeFactory.build(exchangeName, type, new AmqArguments(arguments), this));
         return new AMQImpl.Exchange.DeclareOk();
     }
 

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockNode.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockNode.java
@@ -10,12 +10,14 @@ import com.rabbitmq.client.Consumer;
 import com.rabbitmq.client.GetResponse;
 import com.rabbitmq.client.impl.AMQImpl;
 
+import com.github.fridujo.rabbitmq.mock.configuration.Configuration;
 import com.github.fridujo.rabbitmq.mock.exchange.MockDefaultExchange;
 import com.github.fridujo.rabbitmq.mock.exchange.MockExchange;
 import com.github.fridujo.rabbitmq.mock.exchange.MockExchangeFactory;
 
 public class MockNode implements ReceiverRegistry, TransactionalOperations {
 
+    private final Configuration configuration = new Configuration();
     private final MockDefaultExchange defaultExchange = new MockDefaultExchange(this);
     private final Map<String, MockExchange> exchanges = new ConcurrentHashMap<>();
     private final Map<String, MockQueue> queues = new ConcurrentHashMap<>();
@@ -177,5 +179,9 @@ public class MockNode implements ReceiverRegistry, TransactionalOperations {
     public void close() {
         queues.values().forEach(MockQueue::notifyDeleted);
         queues.values().forEach(MockQueue::close);
+    }
+
+    public Configuration getConfiguration() {
+        return configuration;
     }
 }

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/compatibility/MockConnectionFactoryWithoutAddressResolver.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/compatibility/MockConnectionFactoryWithoutAddressResolver.java
@@ -1,5 +1,6 @@
 package com.github.fridujo.rabbitmq.mock.compatibility;
 
+import com.github.fridujo.rabbitmq.mock.ConfigurableConnectionFactory;
 import com.github.fridujo.rabbitmq.mock.MockConnection;
 import com.github.fridujo.rabbitmq.mock.MockNode;
 import com.github.fridujo.rabbitmq.mock.metrics.MetricsCollectorWrapper;
@@ -10,10 +11,7 @@ import com.rabbitmq.client.ConnectionFactory;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
-public class MockConnectionFactoryWithoutAddressResolver extends ConnectionFactory {
-
-    private final MockNode mockNode = new MockNode();
-
+public class MockConnectionFactoryWithoutAddressResolver extends ConfigurableConnectionFactory<MockConnectionFactoryWithoutAddressResolver> {
 
     public MockConnectionFactoryWithoutAddressResolver() {
         setAutomaticRecoveryEnabled(false);

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/configuration/Configuration.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/configuration/Configuration.java
@@ -1,4 +1,22 @@
 package com.github.fridujo.rabbitmq.mock.configuration;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.github.fridujo.rabbitmq.mock.exchange.MockExchangeCreator;
+
 public class Configuration {
+    private Map<String, MockExchangeCreator> additionalExchangeCreatorsByType = new LinkedHashMap<>();
+
+    public void registerAdditionalExchangeCreator(MockExchangeCreator mockExchangeCreator) {
+        additionalExchangeCreatorsByType.put(mockExchangeCreator.getType(), mockExchangeCreator);
+    }
+
+    public MockExchangeCreator getAdditionalExchangeByType(String type) {
+        return additionalExchangeCreatorsByType.get(type);
+    }
+    
+    public boolean isAdditionalExchangeRegisteredFor(String type) {
+        return additionalExchangeCreatorsByType.containsKey(type);
+    }
 }

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/configuration/Configuration.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/configuration/Configuration.java
@@ -1,0 +1,4 @@
+package com.github.fridujo.rabbitmq.mock.configuration;
+
+public class Configuration {
+}

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/exchange/MockExchangeCreator.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/exchange/MockExchangeCreator.java
@@ -1,0 +1,11 @@
+package com.github.fridujo.rabbitmq.mock.exchange;
+
+import com.github.fridujo.rabbitmq.mock.AmqArguments;
+import com.github.fridujo.rabbitmq.mock.ReceiverRegistry;
+
+public interface MockExchangeCreator {
+
+    String getType();
+
+    BindableMockExchange createMockExchange(String exchangeName, AmqArguments arguments, ReceiverRegistry receiverRegistry);
+}

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/exchange/MockExchangeFactory.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/exchange/MockExchangeFactory.java
@@ -2,9 +2,20 @@ package com.github.fridujo.rabbitmq.mock.exchange;
 
 import com.github.fridujo.rabbitmq.mock.AmqArguments;
 import com.github.fridujo.rabbitmq.mock.ReceiverRegistry;
+import com.github.fridujo.rabbitmq.mock.configuration.Configuration;
 
-public abstract class MockExchangeFactory {
-    public static BindableMockExchange build(String exchangeName, String type, AmqArguments arguments, ReceiverRegistry receiverRegistry) {
+public class MockExchangeFactory {
+
+    private final Configuration configuration;
+
+    public MockExchangeFactory(Configuration configuration) {
+        this.configuration = configuration;
+    }
+
+    public BindableMockExchange build(String exchangeName,
+                                      String type,
+                                      AmqArguments arguments,
+                                      ReceiverRegistry receiverRegistry) {
         if ("topic".equals(type)) {
             return new MockTopicExchange(exchangeName, arguments, receiverRegistry);
         } else if ("direct".equals(type)) {
@@ -13,6 +24,9 @@ public abstract class MockExchangeFactory {
             return new MockFanoutExchange(exchangeName, arguments, receiverRegistry);
         } else if ("headers".equals(type)) {
             return new MockHeadersExchange(exchangeName, arguments, receiverRegistry);
+        } else if (configuration.isAdditionalExchangeRegisteredFor(type)) {
+            return configuration.getAdditionalExchangeByType(type)
+                .createMockExchange(exchangeName, arguments, receiverRegistry);
         }
         throw new IllegalArgumentException("No exchange type " + type);
     }

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/exchange/ExchangeTest.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/exchange/ExchangeTest.java
@@ -25,18 +25,29 @@ import com.github.fridujo.rabbitmq.mock.AmqArguments;
 import com.github.fridujo.rabbitmq.mock.MockNode;
 import com.github.fridujo.rabbitmq.mock.MockQueue;
 import com.github.fridujo.rabbitmq.mock.ReceiverRegistry;
+import com.github.fridujo.rabbitmq.mock.configuration.Configuration;
 
 class ExchangeTest {
 
-    private static AmqArguments empty() {
+    private final Configuration configuration = new Configuration();
+    private final MockExchangeFactory mockExchangeFactory = new MockExchangeFactory(configuration);
+
+    private static final AmqArguments empty() {
         return new AmqArguments(emptyMap());
     }
 
     @Test
     void mockExchangeFactory_throws_if_type_is_unknown() {
         assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(() -> MockExchangeFactory.build("test", "unknown type", empty(), mock(ReceiverRegistry.class)))
+            .isThrownBy(() -> mockExchangeFactory.build("test", "unknown type", empty(), mock(ReceiverRegistry.class)))
             .withMessage("No exchange type unknown type");
+    }
+
+    @Test
+    void mockExchangeFactory_register_new_mock_exchange() {
+        configuration.registerAdditionalExchangeCreator(new FixDelayExchangeCreator());
+        BindableMockExchange xDelayedMockExchange = mockExchangeFactory.build("test", "x-fix-delayed-message", empty(), mock(ReceiverRegistry.class));
+        assertThat(xDelayedMockExchange).isExactlyInstanceOf(FixDelayExchangeCreator.FixDelayExchange.class);
     }
 
     @Nested
@@ -47,7 +58,7 @@ class ExchangeTest {
             "some.other.key, some.other.key"
         })
         void binding_key_matches_routing_key(String bindingKey, String routingKey) {
-            BindableMockExchange directExchange = MockExchangeFactory.build("test", BuiltinExchangeType.DIRECT.getType(), empty(), mock(ReceiverRegistry.class));
+            BindableMockExchange directExchange = mockExchangeFactory.build("test", BuiltinExchangeType.DIRECT.getType(), empty(), mock(ReceiverRegistry.class));
 
             assertThat(directExchange.match(bindingKey, emptyMap(), routingKey, emptyMap())).isTrue();
         }
@@ -59,7 +70,7 @@ class ExchangeTest {
             "lazy.#, lazy.pink.rabbit"
         })
         void binding_key_does_not_match_routing_key(String bindingKey, String routingKey) {
-            BindableMockExchange directExchange = MockExchangeFactory.build("test", BuiltinExchangeType.DIRECT.getType(), empty(), mock(ReceiverRegistry.class));
+            BindableMockExchange directExchange = mockExchangeFactory.build("test", BuiltinExchangeType.DIRECT.getType(), empty(), mock(ReceiverRegistry.class));
 
             assertThat(directExchange.match(bindingKey, emptyMap(), routingKey, emptyMap())).isFalse();
         }
@@ -82,7 +93,7 @@ class ExchangeTest {
             "lazy.#, quick.brown.fox"
         })
         void binding_key_matches_routing_key(String bindingKey, String routingKey) {
-            BindableMockExchange fanoutExchange = MockExchangeFactory.build("test", BuiltinExchangeType.FANOUT.getType(), empty(), mock(ReceiverRegistry.class));
+            BindableMockExchange fanoutExchange = mockExchangeFactory.build("test", BuiltinExchangeType.FANOUT.getType(), empty(), mock(ReceiverRegistry.class));
 
             assertThat(fanoutExchange.match(bindingKey, emptyMap(), routingKey, emptyMap())).isTrue();
         }
@@ -99,7 +110,7 @@ class ExchangeTest {
             "lazy.#, lazy.pink.rabbit"
         })
         void binding_key_matches_routing_key(String bindingKey, String routingKey) {
-            BindableMockExchange topicExchange = MockExchangeFactory.build("test", BuiltinExchangeType.TOPIC.getType(), empty(), mock(ReceiverRegistry.class));
+            BindableMockExchange topicExchange = mockExchangeFactory.build("test", BuiltinExchangeType.TOPIC.getType(), empty(), mock(ReceiverRegistry.class));
 
             assertThat(topicExchange.match(bindingKey, emptyMap(), routingKey, emptyMap())).isTrue();
         }
@@ -114,7 +125,7 @@ class ExchangeTest {
             "lazy.#, quick.brown.fox"
         })
         void binding_key_does_not_match_routing_key(String bindingKey, String routingKey) {
-            BindableMockExchange topicExchange = MockExchangeFactory.build("test", BuiltinExchangeType.TOPIC.getType(), empty(), mock(ReceiverRegistry.class));
+            BindableMockExchange topicExchange = mockExchangeFactory.build("test", BuiltinExchangeType.TOPIC.getType(), empty(), mock(ReceiverRegistry.class));
 
             assertThat(topicExchange.match(bindingKey, emptyMap(), routingKey, emptyMap())).isFalse();
         }
@@ -131,7 +142,7 @@ class ExchangeTest {
             "'os, linux, cores, 8', true",
         })
         void headers_topic_without_x_match_does_not_match_if_one_header_is_not_matching(String headers, boolean matches) {
-            BindableMockExchange headersExchange = MockExchangeFactory.build("test", BuiltinExchangeType.HEADERS.getType(), empty(), mock(ReceiverRegistry.class));
+            BindableMockExchange headersExchange = mockExchangeFactory.build("test", BuiltinExchangeType.HEADERS.getType(), empty(), mock(ReceiverRegistry.class));
 
             assertThat(headersExchange.match("unused", map("os", "linux", "cores", "8"), "unused", map(headers.split(",\\s*")))).isEqualTo(matches);
         }
@@ -144,7 +155,7 @@ class ExchangeTest {
             "'os, linux, cores, 8', true",
         })
         void headers_topic_with_x_match_all_does_not_match_if_one_header_is_not_matching(String headers, boolean matches) {
-            BindableMockExchange headersExchange = MockExchangeFactory.build("test", BuiltinExchangeType.HEADERS.getType(), empty(), mock(ReceiverRegistry.class));
+            BindableMockExchange headersExchange = mockExchangeFactory.build("test", BuiltinExchangeType.HEADERS.getType(), empty(), mock(ReceiverRegistry.class));
 
             assertThat(headersExchange.match("unused", map("os", "linux", "cores", "8", "x-match", "all"), "unused", map(headers.split(",\\s*")))).isEqualTo(matches);
         }
@@ -159,7 +170,7 @@ class ExchangeTest {
             "'os, ios, cores, 8', true",
         })
         void headers_topic_with_x_match_any_matches_if_one_header_is_matching(String headers, boolean matches) {
-            BindableMockExchange headersExchange = MockExchangeFactory.build("test", BuiltinExchangeType.HEADERS.getType(), empty(), mock(ReceiverRegistry.class));
+            BindableMockExchange headersExchange = mockExchangeFactory.build("test", BuiltinExchangeType.HEADERS.getType(), empty(), mock(ReceiverRegistry.class));
 
             assertThat(headersExchange.match("unused", map("os", "linux", "cores", "8", "x-match", "any"), "unused", map(headers.split(",\\s*")))).isEqualTo(matches);
         }

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/exchange/FixDelayExchangeCreator.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/exchange/FixDelayExchangeCreator.java
@@ -1,0 +1,42 @@
+package com.github.fridujo.rabbitmq.mock.exchange;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import com.rabbitmq.client.AMQP;
+
+import com.github.fridujo.rabbitmq.mock.AmqArguments;
+import com.github.fridujo.rabbitmq.mock.ReceiverRegistry;
+
+public class FixDelayExchangeCreator implements MockExchangeCreator {
+    @Override
+    public String getType() {
+        return "x-fix-delayed-message";
+    }
+
+    @Override
+    public BindableMockExchange createMockExchange(String exchangeName, AmqArguments arguments, ReceiverRegistry receiverRegistry) {
+        return new FixDelayExchange(exchangeName, arguments, receiverRegistry);
+    }
+
+    static class FixDelayExchange extends BindableMockExchange {
+
+        private FixDelayExchange(String name, AmqArguments arguments, ReceiverRegistry receiverRegistry) {
+            super(name, arguments, receiverRegistry);
+        }
+
+        @Override
+        public void publish(String previousExchangeName, String routingKey, AMQP.BasicProperties props, byte[] body) {
+            try {
+                TimeUnit.SECONDS.sleep(1);
+            } catch (InterruptedException e) {
+            }
+            super.publish(previousExchangeName, routingKey, props, body);
+        }
+
+        @Override
+        protected boolean match(String bindingKey, Map<String, Object> bindArguments, String routingKey, Map<String, Object> headers) {
+            return bindingKey.equals(routingKey);
+        }
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/spring/SpringIntegrationTest.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/spring/SpringIntegrationTest.java
@@ -1,6 +1,14 @@
 package com.github.fridujo.rabbitmq.mock.spring;
 
-import com.github.fridujo.rabbitmq.mock.MockConnectionFactory;
+import static java.time.Duration.ofMillis;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Message;
@@ -18,14 +26,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-
-import static java.time.Duration.ofMillis;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import com.github.fridujo.rabbitmq.mock.MockConnectionFactory;
+import com.github.fridujo.rabbitmq.mock.exchange.FixDelayExchangeCreator;
 
 class SpringIntegrationTest {
 
@@ -96,7 +98,10 @@ class SpringIntegrationTest {
 
         @Bean
         ConnectionFactory connectionFactory() {
-            return new CachingConnectionFactory(new MockConnectionFactory());
+            return new CachingConnectionFactory(
+                new MockConnectionFactory()
+                    .withAdditionalExchange(new FixDelayExchangeCreator())
+            );
         }
 
         @Bean


### PR DESCRIPTION
Following #32 .
With modifications regarding the scope of the configuration (additional exchanges for now).

Configuration is bounded to instances of `MockConnectionFactory`.

@jnbis I was not able to push on your branch, so I created a new one.
I also changed the author of the commit to reflect that this was your initiative.

If you are ok with the look of it, we can merge it :smiley: 