### PR TITLE
Set version in server properties.

### DIFF
--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockConnection.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockConnection.java
@@ -12,6 +12,8 @@ import com.rabbitmq.client.ShutdownSignalException;
 import com.rabbitmq.client.UnblockedCallback;
 import com.rabbitmq.client.impl.AMQConnection;
 import com.rabbitmq.client.impl.DefaultExceptionHandler;
+import com.rabbitmq.client.impl.LongStringHelper;
+import com.rabbitmq.client.impl.Version;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -74,7 +76,8 @@ public class MockConnection implements Connection {
 
     @Override
     public Map<String, Object> getServerProperties() {
-        return Collections.emptyMap();
+        return Collections.singletonMap("version",
+            LongStringHelper.asLongString(new Version(AMQP.PROTOCOL.MAJOR, AMQP.PROTOCOL.MINOR).toString()));
     }
 
     @Override

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionTest.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockConnectionTest.java
@@ -1,18 +1,21 @@
 package com.github.fridujo.rabbitmq.mock;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-
-import java.io.IOException;
-import java.util.UUID;
-
+import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AlreadyClosedException;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.impl.AMQConnection;
 import com.rabbitmq.client.impl.DefaultExceptionHandler;
+import com.rabbitmq.client.impl.LongStringHelper;
+import com.rabbitmq.client.impl.Version;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class MockConnectionTest {
 
@@ -28,7 +31,8 @@ class MockConnectionTest {
         softly.assertThat(connection.getHeartbeat()).isEqualTo(0);
         softly.assertThat(connection.getClientProperties()).isEqualTo(AMQConnection.defaultClientProperties());
         softly.assertThat(connection.getClientProvidedName()).isNull();
-        softly.assertThat(connection.getServerProperties()).isEmpty();
+        softly.assertThat(connection.getServerProperties().get("version"))
+            .isEqualTo(LongStringHelper.asLongString(new Version(AMQP.PROTOCOL.MAJOR, AMQP.PROTOCOL.MINOR).toString()));
         softly.assertThat(connection.getExceptionHandler()).isExactlyInstanceOf(DefaultExceptionHandler.class);
         softly.assertAll();
     }


### PR DESCRIPTION
I have an app wherein Spring Actuator wants to check the health of services, including RabbitMQ. As you can see in https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/amqp/RabbitHealthIndicator.java, #getVersion expects getServerProperties().get("version") to be non-null.