### PR TITLE
Restart delivery loop for new connections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,18 @@
                             </pomIncludes>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>Alpakka</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>integration-test</phase>
+                        <configuration>
+                            <pomIncludes>
+                                <pomInclude>alpakka/pom.xml</pomInclude>
+                            </pomIncludes>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/src/it/alpakka/pom.xml
+++ b/src/it/alpakka/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.fridujo</groupId>
+    <artifactId>rabbitmq-mock-alpakka-amqp-integration</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <name>RabbitMQ-Mock Alpakka AMQP Integration</name>
+    <description>Integration of RabbitMQ-Mock with Alpakka AMQP</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
+        <rabbitmq-mock.version>@rabbitmq-mock.version@</rabbitmq-mock.version>
+
+        <scala.version>2.13.0</scala.version>
+        <akka.version>2.5.25</akka.version>
+        <alpakka.version>1.1.1</alpakka.version>
+        <junit.version>5.5.2</junit.version>
+
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.lightbend.akka</groupId>
+            <artifactId>akka-stream-alpakka-amqp_2.13</artifactId>
+            <version>${alpakka.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.fridujo</groupId>
+            <artifactId>rabbitmq-mock</artifactId>
+            <version>${rabbitmq-mock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-stream-testkit_2.13</artifactId>
+            <version>${akka.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/src/it/alpakka/src/test/java/com/github/fridujo/rabbitmq/mock/integration/alpakka/AmqpConnectorsTest.java
+++ b/src/it/alpakka/src/test/java/com/github/fridujo/rabbitmq/mock/integration/alpakka/AmqpConnectorsTest.java
@@ -1,0 +1,169 @@
+package com.github.fridujo.rabbitmq.mock.integration.alpakka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.github.fridujo.rabbitmq.mock.compatibility.MockConnectionFactoryFactory;
+
+import akka.Done;
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.japi.Pair;
+import akka.stream.ActorMaterializer;
+import akka.stream.KillSwitches;
+import akka.stream.Materializer;
+import akka.stream.UniqueKillSwitch;
+import akka.stream.alpakka.amqp.AmqpConnectionFactoryConnectionProvider;
+import akka.stream.alpakka.amqp.AmqpConnectionProvider;
+import akka.stream.alpakka.amqp.AmqpReplyToSinkSettings;
+import akka.stream.alpakka.amqp.AmqpWriteSettings;
+import akka.stream.alpakka.amqp.NamedQueueSourceSettings;
+import akka.stream.alpakka.amqp.QueueDeclaration;
+import akka.stream.alpakka.amqp.ReadResult;
+import akka.stream.alpakka.amqp.WriteMessage;
+import akka.stream.alpakka.amqp.javadsl.AmqpRpcFlow;
+import akka.stream.alpakka.amqp.javadsl.AmqpSink;
+import akka.stream.alpakka.amqp.javadsl.AmqpSource;
+import akka.stream.alpakka.amqp.javadsl.CommittableReadResult;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.Keep;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.stream.testkit.TestSubscriber;
+import akka.stream.testkit.javadsl.StreamTestKit;
+import akka.stream.testkit.javadsl.TestSink;
+import akka.testkit.javadsl.TestKit;
+import akka.util.ByteString;
+import scala.collection.JavaConverters;
+import scala.concurrent.duration.Duration;
+
+/**
+ * Shamefully copied from the <a href="https://github.com/akka/alpakka">Alpakka project</a> (under Apache 2.0 license).
+ */
+class AmqpConnectorsTest {
+
+    private static ActorSystem system;
+    private static Materializer materializer;
+
+    private AmqpConnectionProvider connectionProvider = AmqpConnectionFactoryConnectionProvider.create(MockConnectionFactoryFactory.build());
+
+    @BeforeAll
+    public static void setUp() {
+        system = ActorSystem.create();
+        materializer = ActorMaterializer.create(system);
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        TestKit.shutdownActorSystem(system);
+    }
+
+    @AfterEach
+    public void checkForStageLeaks() {
+        StreamTestKit.assertAllStagesStopped(materializer);
+    }
+
+    @Test
+    public void publishAndConsumeRpcWithoutAutoAck() throws Exception {
+
+        final String queueName = "amqp-conn-it-spec-rpc-queue-" + System.currentTimeMillis();
+        final QueueDeclaration queueDeclaration = QueueDeclaration.create(queueName);
+
+        final List<String> input = Arrays.asList("one", "two", "three", "four", "five");
+
+        final Flow<WriteMessage, CommittableReadResult, CompletionStage<String>> ampqRpcFlow =
+            AmqpRpcFlow.committableFlow(
+                AmqpWriteSettings.create(connectionProvider)
+                    .withRoutingKey(queueName)
+                    .withDeclaration(queueDeclaration),
+                10,
+                1);
+        Pair<CompletionStage<String>, TestSubscriber.Probe<ReadResult>> result =
+            Source.from(input)
+                .map(ByteString::fromString)
+                .map(bytes -> WriteMessage.create(bytes))
+                .viaMat(ampqRpcFlow, Keep.right())
+                .mapAsync(1, cm -> cm.ack().thenApply(unused -> cm.message()))
+                .toMat(TestSink.probe(system), Keep.both())
+                .run(materializer);
+
+        result.first().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+        Sink<WriteMessage, CompletionStage<Done>> amqpSink =
+            AmqpSink.createReplyTo(AmqpReplyToSinkSettings.create(connectionProvider));
+
+        final Source<ReadResult, NotUsed> amqpSource =
+            AmqpSource.atMostOnceSource(
+                NamedQueueSourceSettings.create(connectionProvider, queueName)
+                    .withDeclaration(queueDeclaration),
+                1);
+
+        UniqueKillSwitch sourceToSink =
+            amqpSource
+                .viaMat(KillSwitches.single(), Keep.right())
+                .map(b -> WriteMessage.create(b.bytes()).withProperties(b.properties()))
+                .to(amqpSink)
+                .run(materializer);
+
+        List<ReadResult> probeResult =
+            JavaConverters.seqAsJavaListConverter(
+                result.second().toStrict(Duration.create(3, TimeUnit.SECONDS)))
+                .asJava();
+        assertEquals(
+            probeResult.stream().map(s -> s.bytes().utf8String()).collect(Collectors.toList()), input);
+        sourceToSink.shutdown();
+    }
+
+    @Test
+    public void keepConnectionOpenIfDownstreamClosesAndThereArePendingAcks() throws Exception {
+        final String queueName = "amqp-conn-it-spec-simple-queue-" + System.currentTimeMillis();
+        final QueueDeclaration queueDeclaration = QueueDeclaration.create(queueName);
+
+        final Sink<ByteString, CompletionStage<Done>> amqpSink =
+            AmqpSink.createSimple(
+                AmqpWriteSettings.create(connectionProvider)
+                    .withRoutingKey(queueName)
+                    .withDeclaration(queueDeclaration));
+
+        final Integer bufferSize = 10;
+        final Source<CommittableReadResult, NotUsed> amqpSource =
+            AmqpSource.committableSource(
+                NamedQueueSourceSettings.create(connectionProvider, queueName)
+                    .withDeclaration(queueDeclaration),
+                bufferSize);
+
+        final List<String> input = Arrays.asList("one", "two", "three", "four", "five");
+        Source.from(input)
+            .map(ByteString::fromString)
+            .runWith(amqpSink, materializer)
+            .toCompletableFuture()
+            .get(3, TimeUnit.SECONDS);
+
+        final CompletionStage<List<CommittableReadResult>> result =
+            amqpSource.take(input.size()).runWith(Sink.seq(), materializer);
+
+        List<CommittableReadResult> committableMessages =
+            result.toCompletableFuture().get(3, TimeUnit.SECONDS);
+
+        assertEquals(input.size(), committableMessages.size());
+        committableMessages.forEach(
+            cm -> {
+                try {
+                    cm.ack(false).toCompletableFuture().get(3, TimeUnit.SECONDS);
+                } catch (Exception e) {
+                    fail(e.getMessage());
+                }
+            });
+    }
+}

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/DeadLettering.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/DeadLettering.java
@@ -65,6 +65,7 @@ public interface DeadLettering {
             return entry;
         }
 
+        @SuppressWarnings("unchecked")
         public AMQP.BasicProperties prependOn(AMQP.BasicProperties props) {
             Map<String, Object> headers = Optional.ofNullable(props.getHeaders()).map(HashMap::new).orElseGet(HashMap::new);
 

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockConnection.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockConnection.java
@@ -33,7 +33,7 @@ public class MockConnection implements Connection {
     private String id;
 
     public MockConnection(MockNode mockNode, MetricsCollectorWrapper metricsCollectorWrapper) {
-        this.mockNode = mockNode;
+        this.mockNode = mockNode.restartDeliveryLoops();
         this.metricsCollectorWrapper = metricsCollectorWrapper;
         this.address = new InetSocketAddress("127.0.0.1", 0).getAddress();
         this.metricsCollectorWrapper.newConnection(this);

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockNode.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockNode.java
@@ -177,8 +177,12 @@ public class MockNode implements ReceiverRegistry, TransactionalOperations {
         return queue.consumerCount();
     }
 
+    public MockNode restartDeliveryLoops() {
+        queues.values().forEach(MockQueue::restartDeliveryLoop);
+        return this;
+    }
+
     public void close() {
-        queues.values().forEach(MockQueue::notifyDeleted);
         queues.values().forEach(MockQueue::close);
     }
 

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockQueue.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockQueue.java
@@ -146,7 +146,7 @@ public class MockQueue implements Receiver {
         } else {
             LOGGER.debug(localized("Message published" + ": " + message));
         }
-        boolean messagePersisted = messages.offer(message);
+        messages.offer(message);
         if (queueLengthLimitReached) {
             deadLetterWithReason(messages.poll(), DeadLettering.ReasonType.MAX_LEN);
         }

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/tool/RestartableExecutorService.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/tool/RestartableExecutorService.java
@@ -1,0 +1,95 @@
+package com.github.fridujo.rabbitmq.mock.tool;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+public class RestartableExecutorService implements ExecutorService {
+
+    private final Supplier<ExecutorService> executorServiceFactory;
+    private ExecutorService delegate;
+
+    public RestartableExecutorService(Supplier<ExecutorService> executorServiceFactory) {
+        this.executorServiceFactory = executorServiceFactory;
+        this.delegate = executorServiceFactory.get();
+    }
+
+    @Override
+    public void shutdown() {
+        delegate.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return delegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return delegate.submit(task);
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return delegate.submit(task, result);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return delegate.submit(task);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return delegate.invokeAll(tasks);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.invokeAll(tasks, timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return delegate.invokeAny(tasks);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return delegate.invokeAny(tasks, timeout, unit);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        delegate.execute(command);
+    }
+
+    public synchronized void restart() {
+        this.delegate = executorServiceFactory.get();
+    }
+
+    public ExecutorService getDelegate() {
+        return delegate;
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/tool/RestartableExecutorServiceTest.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/tool/RestartableExecutorServiceTest.java
@@ -1,0 +1,78 @@
+package com.github.fridujo.rabbitmq.mock.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+class RestartableExecutorServiceTest {
+
+    @Test
+    void all_calls_delegates() throws InterruptedException, ExecutionException, TimeoutException {
+        ExecutorService delegate = mock(ExecutorService.class);
+        ExecutorService executorService = new RestartableExecutorService(() -> delegate);
+
+        executorService.shutdown();
+        verify(delegate, atLeastOnce()).shutdown();
+
+        executorService.shutdownNow();
+        verify(delegate, atLeastOnce()).shutdownNow();
+
+        executorService.isShutdown();
+        verify(delegate, atLeastOnce()).isShutdown();
+
+        executorService.isTerminated();
+        verify(delegate, atLeastOnce()).isTerminated();
+
+        executorService.awaitTermination(3L, TimeUnit.SECONDS);
+        verify(delegate, atLeastOnce()).awaitTermination(3L, TimeUnit.SECONDS);
+
+        executorService.submit(mock(Callable.class));
+        verify(delegate, atLeastOnce()).submit(any(Callable.class));
+
+        executorService.submit(mock(Runnable.class), new Object());
+        verify(delegate, atLeastOnce()).submit(any(Runnable.class), any());
+
+        executorService.submit(mock(Runnable.class));
+        verify(delegate, atLeastOnce()).submit(any(Runnable.class));
+
+        executorService.invokeAll(Collections.<Callable<Object>>singletonList(mock(Callable.class)));
+        verify(delegate, atLeastOnce()).invokeAll(any());
+
+        executorService.invokeAll(Collections.<Callable<Object>>singletonList(mock(Callable.class)), 7L, TimeUnit.MILLISECONDS);
+        verify(delegate, atLeastOnce()).invokeAll(any(), eq(7L), eq(TimeUnit.MILLISECONDS));
+
+        executorService.invokeAny(Collections.<Callable<Object>>singletonList(mock(Callable.class)));
+        verify(delegate, atLeastOnce()).invokeAny(any());
+
+        executorService.invokeAny(Collections.<Callable<Object>>singletonList(mock(Callable.class)), 7L, TimeUnit.MILLISECONDS);
+        verify(delegate, atLeastOnce()).invokeAny(any(), eq(7L), eq(TimeUnit.MILLISECONDS));
+
+        executorService.execute(mock(Runnable.class));
+        verify(delegate, atLeastOnce()).execute(any());
+    }
+
+    @Test
+    void restart_creates_a_new_delegate_from_factory() {
+        AtomicInteger counter = new AtomicInteger();
+        RestartableExecutorService executorService = new RestartableExecutorService(() -> mock(ExecutorService.class, "mock" + counter.incrementAndGet()));
+
+        assertThat(executorService.getDelegate()).hasToString("mock1");
+
+        executorService.restart();
+
+        assertThat(executorService.getDelegate()).hasToString("mock2");
+    }
+}


### PR DESCRIPTION
Delivery loop was broken for existing queues after connection was closed.

This is an attempt to fix #44 (as no sample was supplied).