### PR TITLE
Test and Fix for #125

### DIFF
--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockChannel.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockChannel.java
@@ -65,7 +65,7 @@ public class MockChannel implements Channel {
         
         this.directReplyToQueue = 
             node
-                .queueDeclare(generateIfEmpty(""),false, true, true, Collections.emptyMap(), this)
+                .queueDeclare(generateIfEmpty(""),false, true, true, Collections.emptyMap())
                 .getQueue();
 
         metricsCollectorWrapper.newChannel(this);
@@ -319,7 +319,7 @@ public class MockChannel implements Channel {
 
     @Override
     public AMQP.Queue.DeclareOk queueDeclare(String queue, boolean durable, boolean exclusive, boolean autoDelete, Map<String, Object> arguments) {
-        return node.queueDeclare(generateIfEmpty(queue), durable, exclusive, autoDelete, nullToEmpty(arguments), this);
+        return node.queueDeclare(generateIfEmpty(queue), durable, exclusive, autoDelete, nullToEmpty(arguments));
     }
 
     @Override
@@ -509,7 +509,7 @@ public class MockChannel implements Channel {
                 throw new IllegalStateException("direct reply-to requires autoAck");
             }
         }
-        String serverConsumerTag = node.basicConsume(lastGeneratedIfEmpty(queue), autoAck, consumerTag, noLocal, exclusive, nullToEmpty(arguments), callback, this::nextDeliveryTag, mockConnection);
+        String serverConsumerTag = node.basicConsume(lastGeneratedIfEmpty(queue), autoAck, consumerTag, noLocal, exclusive, nullToEmpty(arguments), callback, this::nextDeliveryTag, mockConnection, this);
         metricsCollectorWrapper.basicConsume(this, serverConsumerTag, autoAck);
         return serverConsumerTag;
     }

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockNode.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockNode.java
@@ -37,7 +37,7 @@ public class MockNode implements ReceiverRegistry, TransactionalOperations {
         return exchange.publish(null, routingKey, props, body);
     }
 
-    public String basicConsume(String queueName, boolean autoAck, String consumerTag, boolean noLocal, boolean exclusive, Map<String, Object> arguments, Consumer callback, Supplier<Long> deliveryTagSupplier, MockConnection mockConnection) {
+    public String basicConsume(String queueName, boolean autoAck, String consumerTag, boolean noLocal, boolean exclusive, Map<String, Object> arguments, Consumer callback, Supplier<Long> deliveryTagSupplier, MockConnection mockConnection, MockChannel mockChannel) {
         final String definitiveConsumerTag;
         if ("".equals(consumerTag)) {
             definitiveConsumerTag = consumerTagGenerator.generate();
@@ -45,7 +45,7 @@ public class MockNode implements ReceiverRegistry, TransactionalOperations {
             definitiveConsumerTag = consumerTag;
         }
 
-        getQueueUnchecked(queueName).basicConsume(definitiveConsumerTag, callback, autoAck, deliveryTagSupplier, mockConnection);
+        getQueueUnchecked(queueName).basicConsume(definitiveConsumerTag, callback, autoAck, deliveryTagSupplier, mockConnection, mockChannel);
 
         return definitiveConsumerTag;
     }
@@ -78,8 +78,8 @@ public class MockNode implements ReceiverRegistry, TransactionalOperations {
         return new AMQImpl.Exchange.UnbindOk();
     }
 
-    public AMQP.Queue.DeclareOk queueDeclare(String queueName, boolean durable, boolean exclusive, boolean autoDelete, Map<String, Object> arguments, MockChannel mockChannel) {
-        queues.putIfAbsent(queueName, new MockQueue(queueName, new AmqArguments(arguments), this, mockChannel));
+    public AMQP.Queue.DeclareOk queueDeclare(String queueName, boolean durable, boolean exclusive, boolean autoDelete, Map<String, Object> arguments) {
+        queues.putIfAbsent(queueName, new MockQueue(queueName, new AmqArguments(arguments), this));
         return new AMQP.Queue.DeclareOk.Builder()
             .queue(queueName)
             .build();


### PR DESCRIPTION
Fix for #125.

> When trying to use the MockConnectionFactory for integration tests for a Spring Boot application I noticed that metrics were not complete when using a transaction manager.  Upon further investigation I noticed MockQueue stores the MockChannel used to create it.  It subsequently uses this in deliverToConsumerIfPossible to register consumption.  
> 
> This means that acknowledgements are not recorded in AbstractMetricsCollector.updateChannelStateAfterAckReject for single messages because channelState.unackedMessageDeliveryTags does not contain the consumption, instead it was recorded against the channel used to declare the queue.
> 
> I've provided a PR with two commits.  The first provides a failing test, the second commit introduces a fix which stores the MockChannel in the ConsumerAndTag when basicConsume is called so it can be used when delivering to the consumer.

I came across this whilst creating a Spring Boot integration test since one channel is created by the RabbitAdmin and the other by the RabbitTransactionManager.  I use the metrics to check for acks before testing the output of the application.