### PR TITLE
Issue #127 - Consistent Hash binding key must be integer

### DIFF
--- a/src/main/java/com/github/fridujo/rabbitmq/mock/exchange/ConsistentHashExchange.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/exchange/ConsistentHashExchange.java
@@ -55,7 +55,7 @@ public class ConsistentHashExchange extends SingleReceiverExchange {
         try {
             return Integer.parseInt(routingKey);
         } catch (NumberFormatException e) {
-            return routingKey.hashCode();
+            throw new IllegalArgumentException("The binding key must be an integer");
         }
     }
 

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/exchange/ConsistentHashExchangeTests.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/exchange/ConsistentHashExchangeTests.java
@@ -1,11 +1,11 @@
 package com.github.fridujo.rabbitmq.mock.exchange;
 
-import static com.github.fridujo.rabbitmq.mock.AmqArguments.empty;
-import static com.github.fridujo.rabbitmq.mock.exchange.MockExchangeCreator.creatorWithExchangeType;
-import static java.util.Collections.emptyMap;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.within;
-import static org.mockito.Mockito.mock;
+import com.github.fridujo.rabbitmq.mock.ReceiverPointer;
+import com.github.fridujo.rabbitmq.mock.ReceiverRegistry;
+import com.github.fridujo.rabbitmq.mock.configuration.Configuration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Map;
 import java.util.Optional;
@@ -14,11 +14,13 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.junit.jupiter.api.Test;
-
-import com.github.fridujo.rabbitmq.mock.ReceiverPointer;
-import com.github.fridujo.rabbitmq.mock.ReceiverRegistry;
-import com.github.fridujo.rabbitmq.mock.configuration.Configuration;
+import static com.github.fridujo.rabbitmq.mock.AmqArguments.empty;
+import static com.github.fridujo.rabbitmq.mock.exchange.MockExchangeCreator.creatorWithExchangeType;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.within;
+import static org.mockito.Mockito.mock;
 
 class ConsistentHashExchangeTests {
 
@@ -52,14 +54,11 @@ class ConsistentHashExchangeTests {
         SingleReceiverExchange consistentHashEx = (SingleReceiverExchange) mockExchangeFactory.build("test", "x-consistent-hash", empty(), mock(ReceiverRegistry.class));
 
         ReceiverPointer q1 = new ReceiverPointer(ReceiverPointer.Type.QUEUE, "Q1");
-        consistentHashEx.bind(q1, "32", emptyMap());
+        consistentHashEx.bind(q1, "10", emptyMap());
         ReceiverPointer q2 = new ReceiverPointer(ReceiverPointer.Type.QUEUE, "Q2");
-        consistentHashEx.bind(q2, "64", emptyMap());
+        consistentHashEx.bind(q2, "70", emptyMap());
         ReceiverPointer q3 = new ReceiverPointer(ReceiverPointer.Type.QUEUE, "Q3");
-        consistentHashEx.bind(q3, " ", emptyMap());
-        ReceiverPointer q4 = new ReceiverPointer(ReceiverPointer.Type.QUEUE, "Q4");
-        consistentHashEx.bind(q4, "AA", emptyMap());
-        consistentHashEx.unbind(q4, "AA");
+        consistentHashEx.bind(q3, "20", emptyMap());
 
         int messagesCount = 1_000_000;
         Map<ReceiverPointer, Long> deliveriesByReceiver = IntStream.range(0, messagesCount)
@@ -69,8 +68,21 @@ class ConsistentHashExchangeTests {
 
         assertThat(deliveriesByReceiver).containsOnlyKeys(q1, q2, q3);
 
-        assertThat(Long.valueOf(deliveriesByReceiver.get(q1)).doubleValue() / messagesCount).isCloseTo(0.25D, within(0.01));
-        assertThat(Long.valueOf(deliveriesByReceiver.get(q2)).doubleValue() / messagesCount).isCloseTo(0.5D, within(0.01));
-        assertThat(Long.valueOf(deliveriesByReceiver.get(q3)).doubleValue() / messagesCount).isCloseTo(0.25D, within(0.01));
+        assertThat(Long.valueOf(deliveriesByReceiver.get(q1)).doubleValue() / messagesCount).isCloseTo(0.1D, within(0.01));
+        assertThat(Long.valueOf(deliveriesByReceiver.get(q2)).doubleValue() / messagesCount).isCloseTo(0.7D, within(0.01));
+        assertThat(Long.valueOf(deliveriesByReceiver.get(q3)).doubleValue() / messagesCount).isCloseTo(0.2D, within(0.01));
+    }
+
+
+    @ParameterizedTest(name = "Binding Consistent hash exchange with binding key \"{0}\" throws IllegalArgumentException")
+    @ValueSource(strings = {"", "string", "#"})
+    void binding_with_non_integer_key_throws_exception(String bindingKey) {
+        SingleReceiverExchange consistentHashEx = (SingleReceiverExchange) mockExchangeFactory.build("test", "x-consistent-hash", empty(), mock(ReceiverRegistry.class));
+
+        ReceiverPointer q1 = new ReceiverPointer(ReceiverPointer.Type.QUEUE, "Q1");
+
+        assertThatThrownBy(() -> consistentHashEx.bind(q1, bindingKey, emptyMap()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The binding key must be an integer");
     }
 }


### PR DESCRIPTION
See #127 - Now throws an illegal argument exception on trying to bind rather than using the Hashcode of a non integer.