### PR TITLE
Include bind arguments as part of equals/hashCode in BindConfiguration

### DIFF
--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockNode.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockNode.java
@@ -74,7 +74,7 @@ public class MockNode implements ReceiverRegistry, TransactionalOperations {
     public AMQP.Exchange.UnbindOk exchangeUnbind(String destinationName, String sourceName, String routingKey, Map<String, Object> arguments) {
         MockExchange source = getExchangeUnchecked(sourceName);
         MockExchange destination = getExchangeUnchecked(destinationName);
-        source.unbind(destination.pointer(), routingKey);
+        source.unbind(destination.pointer(), routingKey, arguments);
         return new AMQImpl.Exchange.UnbindOk();
     }
 
@@ -101,7 +101,7 @@ public class MockNode implements ReceiverRegistry, TransactionalOperations {
     public AMQP.Queue.UnbindOk queueUnbind(String queueName, String exchangeName, String routingKey, Map<String, Object> arguments) {
         MockExchange exchange = getExchangeUnchecked(exchangeName);
         MockQueue queue = getQueueUnchecked(queueName);
-        exchange.unbind(queue.pointer(), routingKey);
+        exchange.unbind(queue.pointer(), routingKey, arguments);
         return new AMQImpl.Queue.UnbindOk();
     }
 

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/exchange/BindableMockExchange.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/exchange/BindableMockExchange.java
@@ -1,6 +1,5 @@
 package com.github.fridujo.rabbitmq.mock.exchange;
 
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -81,8 +80,8 @@ public abstract class BindableMockExchange implements MockExchange {
     }
 
     @Override
-    public void unbind(ReceiverPointer receiver, String routingKey) {
-        bindConfigurations.remove(new BindConfiguration(routingKey, receiver, Collections.emptyMap()));
+    public void unbind(ReceiverPointer receiver, String routingKey, Map<String, Object> arguments) {
+        bindConfigurations.remove(new BindConfiguration(routingKey, receiver, arguments));
     }
 
     @Override
@@ -116,12 +115,13 @@ public abstract class BindableMockExchange implements MockExchange {
             if (o == null || getClass() != o.getClass()) return false;
             BindConfiguration that = (BindConfiguration) o;
             return Objects.equals(bindingKey, that.bindingKey) &&
-                Objects.equals(receiverPointer, that.receiverPointer);
+                Objects.equals(receiverPointer, that.receiverPointer) &&
+                Objects.equals(bindArguments, that.bindArguments);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(bindingKey, receiverPointer);
+            return Objects.hash(bindingKey, receiverPointer, bindArguments);
         }
     }
 }

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/exchange/ConsistentHashExchange.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/exchange/ConsistentHashExchange.java
@@ -39,8 +39,8 @@ public class ConsistentHashExchange extends SingleReceiverExchange {
     }
 
     @Override
-    public void unbind(ReceiverPointer receiver, String routingKey) {
-        super.unbind(receiver, routingKey);
+    public void unbind(ReceiverPointer receiver, String routingKey, Map<String, Object> arguments) {
+        super.unbind(receiver, routingKey, arguments);
         buckets.removeIf(b -> b.receiverPointer.equals(receiver));
     }
 

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/exchange/MockDefaultExchange.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/exchange/MockDefaultExchange.java
@@ -34,7 +34,7 @@ public class MockDefaultExchange implements MockExchange {
     }
 
     @Override
-    public void unbind(ReceiverPointer pointer, String routingKey) {
+    public void unbind(ReceiverPointer pointer, String routingKey, Map<String, Object> arguments) {
         // nothing needed
     }
 

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/exchange/MockExchange.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/exchange/MockExchange.java
@@ -11,5 +11,5 @@ public interface MockExchange extends Receiver {
 
     void bind(ReceiverPointer mockQueue, String routingKey, Map<String, Object> arguments);
 
-    void unbind(ReceiverPointer pointer, String routingKey);
+    void unbind(ReceiverPointer pointer, String routingKey, Map<String, Object> arguments);
 }

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/exchange/ConsistentHashExchangeTests.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/exchange/ConsistentHashExchangeTests.java
@@ -59,7 +59,7 @@ class ConsistentHashExchangeTests {
         consistentHashEx.bind(q3, " ", emptyMap());
         ReceiverPointer q4 = new ReceiverPointer(ReceiverPointer.Type.QUEUE, "Q4");
         consistentHashEx.bind(q4, "AA", emptyMap());
-        consistentHashEx.unbind(q4, "AA");
+        consistentHashEx.unbind(q4, "AA", emptyMap());
 
         int messagesCount = 1_000_000;
         Map<ReceiverPointer, Long> deliveriesByReceiver = IntStream.range(0, messagesCount)


### PR DESCRIPTION
We discovered that when creating two queue bindings on the same exchange which only differ in binding arguments that rabbit mock will not deliver messages to the queue for all of the possible bindings (ie, one of the bindings simply does not work despite a message being delivered to the exchange with correct arguments).

This is because the BindConfigurations are at some point compared and its equals/hashCode does not take the binding arguments into account.

This PR shows a potential solution which fixes our test cases.