### PR TITLE
Add new stream typed queue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.fridujo</groupId>
     <artifactId>rabbitmq-mock</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.2.0-naive-streams-SNAPSHOT</version>
 
     <name>RabbitMQ-Mock</name>
     <description>Mock for RabbitMQ Java amqp-client</description>

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/AmqArguments.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/AmqArguments.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 
 public class AmqArguments {
+    public static final String QUEUE_TYPE_KEY = "x-queue-type";
     public static final String DEAD_LETTER_EXCHANGE_KEY = "x-dead-letter-exchange";
     public static final String DEAD_LETTER_ROUTING_KEY_KEY = "x-dead-letter-routing-key";
     public static final String MESSAGE_TTL_KEY = "x-message-ttl";
@@ -66,6 +67,12 @@ public class AmqArguments {
             .map(Integer::shortValue);
     }
 
+    public QueueType queueType() {
+        return string(QUEUE_TYPE_KEY)
+            .flatMap(QueueType::parse)
+            .orElse(QueueType.CLASSIC);
+    }
+
     private Optional<Integer> positiveInteger(String key) {
         return Optional.ofNullable(arguments.get(key))
             .filter(aeObject -> aeObject instanceof Number)
@@ -90,6 +97,25 @@ public class AmqArguments {
         }
 
         private static Optional<Overflow> parse(String value) {
+            return Arrays.stream(values()).filter(v -> value.equals(v.stringValue)).findFirst();
+        }
+
+        @Override
+        public String toString() {
+            return stringValue;
+        }
+    }
+
+    public enum QueueType {
+        CLASSIC("classic"), STREAM("stream");
+
+        private final String stringValue;
+
+        QueueType(String stringValue) {
+            this.stringValue = stringValue;
+        }
+
+        private static Optional<QueueType> parse(String value) {
             return Arrays.stream(values()).filter(v -> value.equals(v.stringValue)).findFirst();
         }
 

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/ConsumerWithArguments.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/ConsumerWithArguments.java
@@ -1,0 +1,10 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import com.rabbitmq.client.Consumer;
+
+import java.util.Map;
+
+public interface ConsumerWithArguments extends Consumer {
+
+    Map<String, Object> getArguments();
+}

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/DecoratedConsumerWithArguments.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/DecoratedConsumerWithArguments.java
@@ -1,0 +1,41 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Consumer;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.ShutdownSignalException;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class DecoratedConsumerWithArguments implements ConsumerWithArguments {
+
+    final private Consumer consumer;
+    final private Map<String, Object> arguments;
+
+    DecoratedConsumerWithArguments(Consumer consumer, Map<String, Object> arguments) {
+        this.consumer = consumer;
+        this.arguments = arguments;
+    }
+
+    @Override
+    public Map<String, Object> getArguments() { return arguments; }
+
+    @Override
+    public void handleConsumeOk(String consumerTag) { consumer.handleConsumeOk(consumerTag); }
+
+    @Override
+    public void handleCancelOk(String consumerTag) { consumer.handleCancelOk(consumerTag); }
+
+    @Override
+    public void handleCancel(String consumerTag) throws IOException { consumer.handleCancel(consumerTag); }
+
+    @Override
+    public void handleShutdownSignal(String consumerTag, ShutdownSignalException sig) { consumer.handleShutdownSignal(consumerTag, sig); }
+
+    @Override
+    public void handleRecoverOk(String consumerTag) { consumer.handleRecoverOk(consumerTag); }
+
+    @Override
+    public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException { consumer.handleDelivery(consumerTag, envelope, properties, body); }
+}

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/Message.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/Message.java
@@ -3,6 +3,8 @@ package com.github.fridujo.rabbitmq.mock;
 import com.rabbitmq.client.AMQP;
 
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 public class Message {
@@ -39,6 +41,16 @@ public class Message {
 
     public int priority() {
         return Optional.ofNullable(props.getPriority()).orElse(0);
+    }
+
+    public Message deliverWithOffset(Long offset) {
+        AMQP.BasicProperties.Builder builder = props.builder();
+        Map<String, Object> oldHeaders = props.getHeaders();
+        Map<String, Object> newHeaders = new HashMap<>();
+        if (oldHeaders != null) newHeaders.putAll(oldHeaders);
+        newHeaders.put("x-stream-offset", offset);
+        AMQP.BasicProperties newProps = builder.headers(newHeaders).build();
+        return new Message(id, exchangeName, routingKey, newProps, body, expiryTime, redelivered);
     }
 
     @Override

--- a/src/main/java/com/github/fridujo/rabbitmq/mock/MockStream.java
+++ b/src/main/java/com/github/fridujo/rabbitmq/mock/MockStream.java
@@ -1,0 +1,414 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import com.github.fridujo.rabbitmq.mock.tool.NamedThreadFactory;
+import com.github.fridujo.rabbitmq.mock.tool.RestartableExecutorService;
+import com.rabbitmq.client.AMQP.BasicProperties;
+import com.rabbitmq.client.Consumer;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.GetResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static com.github.fridujo.rabbitmq.mock.tool.Exceptions.runAndEatExceptions;
+import static com.github.fridujo.rabbitmq.mock.tool.Exceptions.runAndTransformExceptions;
+
+public class MockStream extends MockQueue implements Receiver {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MockStream.class);
+    private static final long SLEEPING_TIME_BETWEEN_SUBMISSIONS_TO_CONSUMERS = 30L;
+
+    private final String name;
+    private final ReceiverPointer pointer;
+    private final AmqArguments arguments;
+    private final List<Message> messageStream = new ArrayList<>();
+    private final Map<Long, Message> messageByOffset = new HashMap<>();
+    private final RestartableExecutorService executorService;
+    private final Map<String, ConsumerAndTag> consumersByTag = new LinkedHashMap<>();
+    private final AtomicInteger consumerRollingSequence = new AtomicInteger();
+    private final AtomicInteger messageSequence = new AtomicInteger();
+    private final AtomicBoolean running = new AtomicBoolean(true);
+    private final Map<ConsumerAndTag, Long> unackedMessageByConsumer = new HashMap<>();
+    private ConsumerAndTag currentConsumer;
+
+    public MockStream(String name, AmqArguments arguments, ReceiverRegistry receiverRegistry) {
+        super(name, arguments, receiverRegistry);
+        this.name = name;
+        this.pointer = new ReceiverPointer(ReceiverPointer.Type.QUEUE, name);
+        this.arguments = arguments;
+        executorService = new RestartableExecutorService(() -> Executors.newFixedThreadPool(1, new NamedThreadFactory(i -> name + "_queue_consuming")));
+        start();
+    }
+
+    private void start() {
+        executorService.submit(() -> {
+            while (running.get()) {
+                while (deliverToConsumerIfPossible()) ;
+                runAndTransformExceptions(
+                    () -> TimeUnit.MILLISECONDS.sleep(SLEEPING_TIME_BETWEEN_SUBMISSIONS_TO_CONSUMERS),
+                    e -> new RuntimeException("Queue " + name + " consumer Thread have been interrupted", e)
+                );
+            }
+        });
+    }
+
+    private Long calculateInitialOffset(ConsumerAndTag consumer) {
+
+        final Map<String, Object> arguments = consumer.arguments;
+        Object o = arguments.getOrDefault("x-stream-offset", "next");
+
+        if (messageByOffset.isEmpty()) {
+            return 0L;
+        } else {
+            Long minOffset = messageByOffset.keySet().stream().mapToLong(Long::longValue).min().orElse(0);
+            Long maxOffset = messageByOffset.keySet().stream().mapToLong(Long::longValue).max().orElse(0);
+            Message first = messageByOffset.get(minOffset);
+            Message last = messageByOffset.get(maxOffset);
+            Date firstTimestamp = first == null ? null : first.props.getTimestamp();
+            Date lastTimestamp = last == null ? null : last.props.getTimestamp();
+            return calculateOffset(o, minOffset, maxOffset, firstTimestamp, lastTimestamp);
+        }
+    }
+
+    private Long calculateOffset(Object offsetArg, Long minOffset, Long maxOffset, Date firstTimestamp, Date lastTimestamp) {
+
+        if (offsetArg instanceof String) {
+            final String s = (String) offsetArg;
+            if (s.equals("first")) {
+                return calculateOffset(0, minOffset, maxOffset, firstTimestamp, lastTimestamp);
+            } else if (s.equals("next")) {
+                return messageByOffset.keySet().stream().mapToLong(Long::longValue).max().orElse(0);
+            } else {
+                String msg = String.format("Cannot understand value [%s] for x-stream-offset", s);
+                throw new RuntimeException(msg);
+            }
+        } else if (offsetArg instanceof Long) {
+            final Long l = (Long) offsetArg;
+            if (l < 0) {
+                return calculateOffset("next", minOffset, maxOffset, firstTimestamp, lastTimestamp);
+            } else {
+                if (l < minOffset) {
+                    return minOffset;
+                } else if (l > maxOffset) {
+                    return maxOffset + 1;
+                } else {
+                    return l;
+                }
+            }
+        } else if (offsetArg instanceof Date) {
+            final Date d = (Date) offsetArg;
+            if (d.before(firstTimestamp)) {
+                return minOffset;
+            } else if (d.after(lastTimestamp)) {
+                return maxOffset + 1;
+            } else if (d.equals(firstTimestamp)) {
+                return calculateOffset(0, minOffset, maxOffset, firstTimestamp, lastTimestamp);
+            } else {
+                final Long o1 = messageByOffset.entrySet().stream()
+                    .filter(p -> d.before(p.getValue().props.getTimestamp()))
+                    .findFirst()
+                    .orElseGet(() -> new Map.Entry<Long, Message>() {
+                        @Override public Long getKey() { return 0L; }
+                        @Override public Message getValue() { return null; }
+                        @Override public Message setValue(Message value) { return null; }
+                    })
+                    .getKey();
+                final Long o2 = o1 + 1;
+                final Message m1 = messageByOffset.get(o1);
+                final Message m2 = messageByOffset.get(o2);
+                final long diff1 = d.getTime() - m1.props.getTimestamp().getTime();
+                final long diff2 = m2.props.getTimestamp().getTime() - d.getTime();
+                return (diff1 < diff2) ? o1 : o2;
+            }
+        }
+        return 0L;
+    }
+
+    private boolean deliverToConsumerIfPossible() {
+        // break the delivery loop in case of a shutdown
+        if (!running.get()) {
+            LOGGER.debug(localized("shutting down"));
+            return false;
+        }
+        boolean delivered = false;
+
+        if (!consumersByTag.isEmpty()) {
+            int index = consumerRollingSequence.incrementAndGet() % consumersByTag.size();
+            ConsumerAndTag nextConsumer = new ArrayList<>(consumersByTag.values()).get(index);
+            currentConsumer = nextConsumer;
+
+            if (unackedMessageByConsumer.containsKey(nextConsumer)) {
+                return true;
+            }
+
+            final long streamOffset = nextConsumer.streamOffset;
+
+            Message originalMessage = messageByOffset.get(streamOffset);
+            if (originalMessage != null) {
+                Message message = originalMessage.deliverWithOffset(streamOffset);
+                if (!message.isExpired()) {
+                    long deliveryTag = nextConsumer.deliveryTagSupplier.get();
+                    unackedMessageByConsumer.put(nextConsumer, deliveryTag);
+                    Envelope envelope = new Envelope(
+                        deliveryTag,
+                        message.redelivered,
+                        message.exchangeName,
+                        message.routingKey
+                    );
+                    try {
+                        LOGGER.debug(localized("delivering message to consumer"));
+                        nextConsumer.mockChannel.getMetricsCollector().consumedMessage(nextConsumer.mockChannel, deliveryTag, nextConsumer.tag);
+                        // handleDelivery must be synchronous if acknowledgements are to be meaningful
+                        // The entire setup is running under a single thread so no other consumers will
+                        // receive a message until the current consumer is done.
+                        nextConsumer.consumer.handleDelivery(nextConsumer.tag, envelope, message.props, message.body);
+
+                        delivered = true;
+                        if (unackedMessageByConsumer.getOrDefault(nextConsumer, null) == null) {
+                            nextConsumer.pushOffset();
+                        } else {
+                            LOGGER.warn(localized("Forgot to acknowledge message. Blocking consumer [" + nextConsumer.tag + "]"));
+                        }
+                    } catch (IOException e) {
+                        LOGGER.warn(localized("Unable to deliver message to consumer [" + nextConsumer.tag + "]"));
+                    }
+                } else {
+                    nextConsumer.pushOffset();
+                    LOGGER.trace(localized("Skipping expired message for consumer [" + nextConsumer.tag + "]"));
+                }
+            } else {
+                LOGGER.trace(localized("no message to deliver to consumer [" + nextConsumer.tag + "]"));
+            }
+        } else {
+            LOGGER.trace(localized("no consumer to deliver message to"));
+        }
+        return delivered;
+    }
+
+    public boolean publish(String exchangeName, String routingKey, BasicProperties props, byte[] body) {
+
+        Message message = new Message(
+            messageSequence.getAndIncrement(),
+            exchangeName,
+            routingKey,
+            props,
+            body,
+            computeExpiryTime(props)
+        );
+        if (message.expiryTime != -1) {
+            LOGGER.debug(localized("Message published expiring at " + Instant.ofEpochMilli(message.expiryTime)) + ": " + message);
+        } else {
+            LOGGER.debug(localized("Message published" + ": " + message));
+        }
+        messageStream.add(message);
+        messageByOffset.put((long) message.id, message);
+        return true;
+    }
+
+    @Override
+    public ReceiverPointer pointer() {
+        return pointer;
+    }
+
+    @Override
+    public void basicConsume(String consumerTag, Consumer consumer, boolean autoAck, Supplier<Long> deliveryTagSupplier, MockConnection mockConnection, MockChannel mockChannel) {
+        LOGGER.debug(localized("registering consumer"));
+        Map<String, Object> arguments;
+        if (consumer instanceof ConsumerWithArguments) {
+            arguments = ((ConsumerWithArguments) consumer).getArguments();
+        } else {
+            arguments = new HashMap<String, Object>() {{ put("x-stream-offset", "next"); }};
+        }
+        ConsumerAndTag consumerAndTag = new ConsumerAndTag(consumerTag, consumer, autoAck, arguments, deliveryTagSupplier, mockConnection, mockChannel);
+        consumerAndTag.streamOffset = calculateInitialOffset(consumerAndTag);
+        consumersByTag.put(consumerTag, consumerAndTag);
+        consumer.handleConsumeOk(consumerTag);
+    }
+
+    public GetResponse basicGet(boolean autoAck, Supplier<Long> deliveryTagSupplier) {
+
+        throw new RuntimeException("Cannot get from Stream. Only consume is allowed");
+    }
+
+    public void basicAck(long deliveryTag, boolean multiple) {
+        if (multiple) {
+            throw new RuntimeException("You may only acknowledge Stream messages one by one");
+        } else {
+            unackedMessageByConsumer.remove(currentConsumer, deliveryTag);
+        }
+    }
+
+    public void basicNack(long deliveryTag, boolean multiple, boolean requeue) {
+        if (multiple) {
+            throw new RuntimeException("You may only acknowledge Stream messages one by one");
+        }
+    }
+
+    public void basicReject(long deliveryTag, boolean requeue) {
+        throw new RuntimeException("Streams do not have dead lettering or requeing");
+    }
+
+    private String localized(String message) {
+        return "[Q " + name + "] " + message;
+    }
+
+    public void basicCancel(String consumerTag) {
+        if (consumersByTag.containsKey(consumerTag)) {
+            Consumer consumer = consumersByTag.remove(consumerTag).consumer;
+            consumer.handleCancelOk(consumerTag);
+        }
+    }
+
+    synchronized void restartDeliveryLoop() {
+        if (!running.get()) {
+            running.set(true);
+            executorService.restart();
+            start();
+        }
+    }
+
+    void notifyDeleted() {
+        close();
+    }
+
+    void close(MockConnection mockConnection) {
+        consumersByTag.entrySet().removeIf(e -> {
+            final boolean mustCancelConsumer = e.getValue().mockConnection == mockConnection;
+            if (mustCancelConsumer) {
+                cancel(e.getValue());
+            }
+            return mustCancelConsumer;
+        });
+        if (consumersByTag.isEmpty()) {
+            running.set(false);
+            stopDeliveryLoop();
+        }
+    }
+
+    private void close() {
+        running.set(false);
+        cancelConsumers();
+        stopDeliveryLoop();
+    }
+
+    private void stopDeliveryLoop() {
+        executorService.shutdown();
+        runAndEatExceptions(() ->
+            executorService.awaitTermination(
+                SLEEPING_TIME_BETWEEN_SUBMISSIONS_TO_CONSUMERS * 3,
+                TimeUnit.MILLISECONDS)
+        );
+    }
+
+    private void cancelConsumers() {
+        for (ConsumerAndTag consumerAndTag : consumersByTag.values()) {
+            cancel(consumerAndTag);
+        }
+        consumersByTag.clear();
+    }
+
+    private void cancel(ConsumerAndTag consumerAndTag) {
+        try {
+            consumerAndTag.consumer.handleCancel(consumerAndTag.tag);
+        } catch (IOException e) {
+            LOGGER.warn("Consumer threw an exception when notified about cancellation", e);
+        }
+    }
+
+    public void basicRecover(boolean requeue) {
+        throw new RuntimeException("There is no recovery in Streams. You may only set the offset to go back.");
+    }
+
+    public int messageCount() {
+        return messageStream.size();
+    }
+
+    public int consumerCount() {
+        return consumersByTag.size();
+    }
+
+    public int purge() {
+        int messageCount = messageCount();
+        messageStream.clear();
+        messageByOffset.clear();
+        return messageCount;
+    }
+
+    private long computeExpiryTime(BasicProperties props) {
+        long messageExpiryTimeOfQueue = arguments
+            .getMessageTtlOfQueue()
+            .map(this::computeExpiry)
+            .orElse(-1L);
+        return getMessageExpiryTime(props).orElse(messageExpiryTimeOfQueue);
+    }
+
+    private Optional<Long> getMessageExpiryTime(BasicProperties props) {
+        return Optional.ofNullable(props.getExpiration())
+            .flatMap(this::toLong)
+            .map(this::computeExpiry);
+    }
+
+    private Long computeExpiry(long ttl) {
+        return System.currentTimeMillis() + ttl;
+    }
+
+    private Optional<Long> toLong(String s) {
+        try {
+            return Optional.of(Long.parseLong(s));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Queue " + name;
+    }
+
+    public List<Message> getAvailableMessages() {
+        return new ArrayList<>(messageStream);
+    }
+
+    public List<Message> getUnackedMessages() {
+        return new ArrayList<>();
+    }
+
+    static class ConsumerAndTag {
+
+        private final String tag;
+        private final Consumer consumer;
+        private final Supplier<Long> deliveryTagSupplier;
+        private final MockConnection mockConnection;
+        private final MockChannel mockChannel;
+        private final Map<String, Object> arguments;
+        private Long streamOffset;
+
+        ConsumerAndTag(String tag, Consumer consumer, boolean autoAck, Map<String, Object> arguments, Supplier<Long> deliveryTagSupplier, MockConnection mockConnection, MockChannel mockChannel) {
+            if (autoAck) {
+                throw new RuntimeException("Streams do not allow autoAck");
+            }
+            this.tag = tag;
+            this.consumer = consumer;
+            this.deliveryTagSupplier = deliveryTagSupplier;
+            this.mockConnection = mockConnection;
+            this.mockChannel = mockChannel;
+            this.arguments = arguments;
+            this.streamOffset = 0L;
+        }
+
+        void pushOffset() { streamOffset++; }
+    }
+}

--- a/src/test/java/com/github/fridujo/rabbitmq/mock/MockStreamTest.java
+++ b/src/test/java/com/github/fridujo/rabbitmq/mock/MockStreamTest.java
@@ -1,0 +1,164 @@
+package com.github.fridujo.rabbitmq.mock;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.DefaultConsumer;
+import com.rabbitmq.client.Envelope;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MockStreamTest {
+
+    private Logger log = LoggerFactory.getLogger(getClass());
+    @Test
+    void basic_consume_case() throws IOException, TimeoutException, InterruptedException {
+
+        final String exchangeName = "test-exchange";
+        final String queueName = "test-queue";
+        final String routingKey = "test-rk";
+        final String consumerTag = "myConsumerTag";
+        final int numMessages = 5;
+        final Long initialOffset = 2L;
+
+        HashMap<String, Object> queueArguments = new HashMap<>();
+        queueArguments.put("x-queue-type", "stream");
+
+        HashMap<String, Object> consumeArguments = new HashMap<>();
+        consumeArguments.put("x-stream-offset", initialOffset);
+
+        try (Connection conn = new MockConnectionFactory().newConnection()) {
+            assertThat(conn).isInstanceOf(MockConnection.class);
+
+            try (Channel channel = conn.createChannel()) {
+                assertThat(channel).isInstanceOf(MockChannel.class);
+
+                channel.exchangeDeclare(exchangeName, "direct", true);
+                channel.queueDeclare(queueName, true, false, false, queueArguments);
+                channel.queueBind(queueName, exchangeName, routingKey);
+
+
+                for (int i = 0; i < numMessages; i++) {
+                    byte[] messageBodyBytes = String.format("Hello number %d!", i).getBytes();
+                    channel.basicPublish(exchangeName, routingKey, null, messageBodyBytes);
+                }
+
+                TimeUnit.MILLISECONDS.sleep(200);
+
+                List<String> messages = new ArrayList<>();
+                channel.basicConsume(queueName, false, consumerTag, false, false, consumeArguments,
+                    new DefaultConsumer(channel) {
+                        @Override
+                        public void handleDelivery(
+                            String consumerTag,
+                            Envelope envelope,
+                            AMQP.BasicProperties properties,
+                            byte[] body
+                        ) throws IOException {
+
+                            long deliveryTag = envelope.getDeliveryTag();
+                            messages.add(new String(body));
+                            channel.basicAck(deliveryTag, false);
+                        }
+                    });
+
+                TimeUnit.SECONDS.sleep(1);
+
+                assertThat(messages).hasSize(numMessages - initialOffset.intValue());
+                assertThat(messages.get(0)).contains("Hello number 2!");
+                assertThat(messages.get(1)).contains("Hello number 3!");
+                assertThat(messages.get(2)).contains("Hello number 4!");
+            }
+        }
+    }
+
+    @Test
+    void multiple_consume_case() throws IOException, TimeoutException, InterruptedException {
+
+        final String exchangeName = "test-exchange";
+        final String queueName = "test-queue";
+        final String routingKey = "test-rk";
+        final String consumerTagA = "myConsumerTagA";
+        final String consumerTagB = "myConsumerTagB";
+        final int numMessages = 5;
+        final Long initialOffsetA = 3L;
+        final Long initialOffsetB = 1L;
+
+        HashMap<String, Object> queueArguments = new HashMap<>();
+        queueArguments.put("x-queue-type", "stream");
+
+        HashMap<String, Object> consumeArgumentsA = new HashMap<>();
+        HashMap<String, Object> consumeArgumentsB = new HashMap<>();
+        consumeArgumentsA.put("x-stream-offset", initialOffsetA);
+        consumeArgumentsB.put("x-stream-offset", initialOffsetB);
+
+        try (Connection conn = new MockConnectionFactory().newConnection()) {
+            assertThat(conn).isInstanceOf(MockConnection.class);
+
+            try (Channel channel = conn.createChannel()) {
+                assertThat(channel).isInstanceOf(MockChannel.class);
+
+                channel.exchangeDeclare(exchangeName, "direct", true);
+                channel.queueDeclare(queueName, true, false, false, queueArguments);
+                channel.queueBind(queueName, exchangeName, routingKey);
+
+
+                for (int i = 0; i < numMessages; i++) {
+                    byte[] messageBodyBytes = String.format("Hello number %d!", i).getBytes();
+                    channel.basicPublish(exchangeName, routingKey, null, messageBodyBytes);
+                }
+
+                TimeUnit.MILLISECONDS.sleep(200);
+
+                List<String> messagesA = new ArrayList<>();
+                List<String> messagesB = new ArrayList<>();
+                DefaultConsumer callbackA = createConsumer(channel, messagesA);
+                DefaultConsumer callbackB = createConsumer(channel, messagesB);
+                channel.basicConsume(queueName, false, consumerTagA, false, false, consumeArgumentsA, callbackA);
+                channel.basicConsume(queueName, false, consumerTagB, false, false, consumeArgumentsB, callbackB);
+
+                TimeUnit.SECONDS.sleep(2);
+
+                assertThat(messagesA).hasSize(numMessages - initialOffsetA.intValue());
+                assertThat(messagesA.get(0)).contains("Hello number 3!");
+                assertThat(messagesA.get(1)).contains("Hello number 4!");
+                assertThat(messagesB).hasSize(numMessages - initialOffsetB.intValue());
+                assertThat(messagesB.get(0)).contains("Hello number 1!");
+                assertThat(messagesB.get(1)).contains("Hello number 2!");
+                assertThat(messagesB.get(2)).contains("Hello number 3!");
+                assertThat(messagesB.get(3)).contains("Hello number 4!");
+            }
+        }
+    }
+
+    private DefaultConsumer createConsumer(Channel channel, List<String> messages) {
+
+        return new DefaultConsumer(channel) {
+
+            @Override public void handleDelivery(
+                String consumerTag,
+                Envelope envelope,
+                AMQP.BasicProperties properties,
+                byte[] body
+            ) throws IOException {
+
+                long deliveryTag = envelope.getDeliveryTag();
+                String m = new String(body);
+                log.info("Consumer [{}] message: {}", consumerTag, m);
+                log.info("Header offset: {}", properties.getHeaders().get("x-stream-offset"));
+                messages.add(m);
+                channel.basicAck(deliveryTag, false);
+            }
+        };
+    }
+}


### PR DESCRIPTION
This contribution derives from issue (feature request) https://github.com/fridujo/rabbitmq-mock/issues/281

This PR is not ready to be merged. There are many things to look out for and the code style is not compliant.

Also, I cannot seem to pass a test for plugin `com.github.fridujo:rabbitmq-mock-alpakka-amqp-integration`

```
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 11.138 s <<< FAILURE! - in com.github.fridujo.rabbitmq.mock.integration.alpakka.AmqpConnectorsTest
[ERROR] publishAndConsumeRpcWithoutAutoAck  Time elapsed: 10.053 s  <<< FAILURE!
java.lang.AssertionError: assertion failed: timeout (4999314094 nanoseconds) during expectMsgClass waiting for interface akka.stream.testkit.TestSubscriber$SubscriberEvent
        at com.github.fridujo.rabbitmq.mock.integration.alpakka.AmqpConnectorsTest.publishAndConsumeRpcWithoutAutoAck(AmqpConnectorsTest.java:121)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   AmqpConnectorsTest.publishAndConsumeRpcWithoutAutoAck:121 assertion failed: timeout (4999314094 nanoseconds) during expectMsgClass waiting for interface akka.stream.testkit.TestSubscriber$SubscriberEvent
[INFO] 
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0
```